### PR TITLE
Improve instance cache metrics and runtime name lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,6 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+/.claude/
+/NuGet.config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Instance cache size metrics are now tracked per generic type.
+- LightweightTrace now supports runtime-discovered names such as generic type names.
+
 ## [1.0.7] - 2026-05-26
 
 ### Added

--- a/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/EquatableImmutableArrayInstanceCache.cs
+++ b/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/EquatableImmutableArrayInstanceCache.cs
@@ -1,4 +1,4 @@
-﻿#if !DATACUTE_EXCLUDE_EQUATABLEIMMUTABLEARRAYINSTANCECACHE // Feature: EquatableImmutableArrayInstanceCache (optional)
+#if !DATACUTE_EXCLUDE_EQUATABLEIMMUTABLEARRAYINSTANCECACHE // Feature: EquatableImmutableArrayInstanceCache (optional)
 #if !DATACUTE_EXCLUDE_EQUATABLEIMMUTABLEARRAY // Dependency: EquatableImmutableArray
 using System;
 using System.Collections.Concurrent;
@@ -13,6 +13,46 @@ namespace Datacute.IncrementalGeneratorExtensions
     // is important.
     // We will use an instance cache to find when we can reuse
     // an existing object, massively speeding up the Equals call.
+
+    /// <summary>
+    /// A registry that keeps track of all generic instances of <see cref="EquatableImmutableArrayInstanceCache{T}"/>
+    /// so that their caches can be cleared in a single operation.
+    /// </summary>
+    public static class EquatableImmutableArrayInstanceCacheRegistry
+    {
+        private static Action _clearActions;
+        // ReSharper disable once ChangeFieldTypeToSystemThreadingLock shared source code needs to work in netStandard 2.0
+        private static readonly object SyncRoot = new object();
+
+        /// <summary>
+        /// Registers a cache clearer action for a specific generic instance.
+        /// </summary>
+        /// <param name="clearAction">The action that clears the cache for a specific type.</param>
+        public static void RegisterClearAction(Action clearAction)
+        {
+            lock (SyncRoot)
+            {
+                if (clearAction != null)
+                {
+                    _clearActions += clearAction;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears all registered instance caches.
+        /// </summary>
+        public static void ClearAll()
+        {
+            Action actions;
+            lock (SyncRoot)
+            {
+                actions = _clearActions;
+            }
+            
+            actions?.Invoke();
+        }
+    }
 
     /// <summary>
     /// A cache for instances of <see cref="EquatableImmutableArray{T}"/>.
@@ -54,6 +94,8 @@ namespace Datacute.IncrementalGeneratorExtensions
             Cache = new ConcurrentDictionary<int, ConcurrentDictionary<int, List<WeakReference<EquatableImmutableArray<T>>>>>();
             LengthDictFactory = _ => new ConcurrentDictionary<int, List<WeakReference<EquatableImmutableArray<T>>>>();
             CandidateListFactory = _ => new List<WeakReference<EquatableImmutableArray<T>>>();
+            
+            EquatableImmutableArrayInstanceCacheRegistry.RegisterClearAction(Clear);
         }
 
         private struct SweepTarget
@@ -67,14 +109,46 @@ namespace Datacute.IncrementalGeneratorExtensions
         // to avoid enumerating ConcurrentDictionary (which boxes on .NET Framework).
         private const int SweepRingSize = 1024;
         private static readonly SweepTarget[] SweepRing = new SweepTarget[SweepRingSize];
-        // ReSharper disable StaticMemberInGenericType the index belongs to the SweepRing
+        // ReSharper disable once StaticMemberInGenericType the index belongs to the SweepRing
         // and is intended to be one per type.
         private static int _sweepRingIndex;
-        // ReSharper restore StaticMemberInGenericType
 
         // Number of buckets inspected during a post-miss sweep.  Large enough to make a
         // meaningful dent in stale entries without adding noticeable cost to the miss path.
         private const int SweepBatchSize = 16;
+
+        /// <summary>
+        /// Clears the cache, removing all stored instances.
+        /// </summary>
+        public static void Clear()
+        {
+            Array.Clear(MruLengths, 0, MruSize);
+            Array.Clear(MruFirstHashes, 0, MruSize);
+            Array.Clear(MruInstances, 0, MruSize);
+            Cache.Clear();
+            Array.Clear(SweepRing, 0, SweepRingSize);
+            
+#if !DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE && !DATACUTE_EXCLUDE_GENERATORSTAGE
+            SetCount(GeneratorStage.EquatableImmutableArrayInstanceCacheSize, 0L);
+#endif
+        }
+
+#if !DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE && !DATACUTE_EXCLUDE_GENERATORSTAGE
+        private static readonly int TypeMapId = LightweightTrace.RegisterName(typeof(T).ToString());
+
+        private static void SetCount<TEnum>(TEnum counterId, long count) where TEnum : Enum
+        {
+            LightweightTrace.SetCount(counterId, TypeMapId, mapValue: true, count);
+        }
+        private static void IncrementCount<TEnum>(TEnum counterId) where TEnum : Enum
+        {
+            LightweightTrace.IncrementCount(counterId, TypeMapId, mapValue: true);
+        }
+        private static void DecrementCount<TEnum>(TEnum counterId) where TEnum : Enum
+        {
+            LightweightTrace.DecrementCount(counterId, TypeMapId, mapValue: true);
+        }
+#endif
 
         /// <summary>
         /// Gets or creates an instance of <see cref="EquatableImmutableArray{T}"/> from the provided values.
@@ -130,7 +204,7 @@ namespace Datacute.IncrementalGeneratorExtensions
                     if (match)
                     {
 #if !DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE && !DATACUTE_EXCLUDE_GENERATORSTAGE
-                        LightweightTrace.IncrementCount(GeneratorStage.EquatableImmutableArrayCacheHit, values.Length);
+                        IncrementCount(GeneratorStage.EquatableImmutableArrayCacheHit);
 #endif
                         return mruCandidate;
                     }
@@ -194,7 +268,7 @@ namespace Datacute.IncrementalGeneratorExtensions
                         {
                             result = existing;
 #if !DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE && !DATACUTE_EXCLUDE_GENERATORSTAGE
-                            LightweightTrace.IncrementCount(GeneratorStage.EquatableImmutableArrayCacheHit, values.Length);
+                            IncrementCount(GeneratorStage.EquatableImmutableArrayCacheHit);
 #endif
                             break;
                         }
@@ -203,8 +277,8 @@ namespace Datacute.IncrementalGeneratorExtensions
                     {
                         // Clean up dead references
 #if !DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE && !DATACUTE_EXCLUDE_GENERATORSTAGE
-                        LightweightTrace.IncrementCount(GeneratorStage.EquatableImmutableArrayCacheWeakReferenceRemoved, values.Length);
-                        LightweightTrace.DecrementCount(GeneratorStage.EquatableImmutableArrayLength, values.Length);
+                        IncrementCount(GeneratorStage.EquatableImmutableArrayCacheWeakReferenceRemoved);
+                        DecrementCount(GeneratorStage.EquatableImmutableArrayInstanceCacheSize);
 #endif
                         candidateList.RemoveAt(i);
                     }
@@ -215,9 +289,9 @@ namespace Datacute.IncrementalGeneratorExtensions
                     // No match found; calculate hash and create new instance
                     var hash = EquatableImmutableArray<T>.CalculateHashCode(values, comparer, firstElementHash, 1);
 #if !DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE && !DATACUTE_EXCLUDE_GENERATORSTAGE
-                    // Record a histogram of the array sizes we are being asked to create
-                    LightweightTrace.IncrementCount(GeneratorStage.EquatableImmutableArrayCacheMiss, values.Length);
-                    LightweightTrace.IncrementCount(GeneratorStage.EquatableImmutableArrayLength, values.Length);
+                    // Record a miss and track the number of cached instances for this type
+                    IncrementCount(GeneratorStage.EquatableImmutableArrayCacheMiss);
+                    IncrementCount(GeneratorStage.EquatableImmutableArrayInstanceCacheSize);
 #endif
                     result = new EquatableImmutableArray<T>(values, hash);
                     candidateList.Add(new WeakReference<EquatableImmutableArray<T>>(result));
@@ -272,7 +346,13 @@ namespace Datacute.IncrementalGeneratorExtensions
                     for (int j = list.Count - 1; j >= 0; j--)
                     {
                         if (!list[j].TryGetTarget(out _))
+                        {
+#if !DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE && !DATACUTE_EXCLUDE_GENERATORSTAGE
+                            IncrementCount(GeneratorStage.EquatableImmutableArrayCacheWeakReferenceRemoved);
+                            DecrementCount(GeneratorStage.EquatableImmutableArrayInstanceCacheSize);
+#endif
                             list.RemoveAt(j);
+                        }
                     }
                     isEmpty = list.Count == 0;
                 }

--- a/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/GeneratorStage.cs
+++ b/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/GeneratorStage.cs
@@ -45,6 +45,7 @@ namespace Datacute.IncrementalGeneratorExtensions
         EquatableImmutableArrayCacheMiss = 19,
         EquatableImmutableArrayCacheWeakReferenceRemoved = 20,
         EquatableImmutableArrayLength = 21,
+        EquatableImmutableArrayInstanceCacheSize = 22,
 #endif
         
         // Generic Method Call Tracing

--- a/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/GeneratorStageDescriptions.cs
+++ b/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/GeneratorStageDescriptions.cs
@@ -62,6 +62,7 @@ namespace Datacute.IncrementalGeneratorExtensions
             { (int)GeneratorStage.EquatableImmutableArrayCacheMiss, "EquatableImmutableArray Cache Miss" },
             { (int)GeneratorStage.EquatableImmutableArrayCacheWeakReferenceRemoved, "EquatableImmutableArray Cache Weak Reference Removed" },
             { (int)GeneratorStage.EquatableImmutableArrayLength, "EquatableImmutableArray Length" },
+            { (int)GeneratorStage.EquatableImmutableArrayInstanceCacheSize, "EquatableImmutableArray Instance Cache Size" },
 #endif
             
             { (int)GeneratorStage.MethodCall, "Method Call" },

--- a/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/LightweightTrace.cs
+++ b/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/LightweightTrace.cs
@@ -232,6 +232,26 @@ namespace Datacute.IncrementalGeneratorExtensions
             => DecrementCount(System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref counterId), value, mapValue);
 
         /// <summary>
+        /// Sets the value of a given key.
+        /// </summary>
+        /// <param name="counterId">The ID of the counter to set.</param>
+        /// <param name="count">The new value for the counter.</param>
+        /// <typeparam name="TEnum">The type of the counter ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
+        public static void SetCount<TEnum>(TEnum counterId, long count) where TEnum : Enum
+            => SetCount(System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref counterId), count);
+
+        /// <summary>
+        /// Sets the value of a given key.
+        /// </summary>
+        /// <param name="counterId">The ID of the counter to set.</param>
+        /// <param name="value">The value associated with the counter, which can be used for additional context or categorization.</param>
+        /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
+        /// <param name="count">The new value for the counter.</param>
+        /// <typeparam name="TEnum">The type of the counter ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
+        public static void SetCount<TEnum>(TEnum counterId, int value, bool mapValue, long count) where TEnum : Enum
+            => SetCount(System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref counterId), value, mapValue, count);
+
+        /// <summary>
         /// Increments the value of a given key by 1.
         /// </summary>
         /// <param name="counterId">The ID of the counter to increment.</param>
@@ -259,6 +279,22 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
         public static void DecrementCount(int counterId, int value, bool mapValue = false) => Interlocked.Decrement(ref GetOrAddCounter(EncodeKey(counterId, value, mapValue)).Value);
 
+        /// <summary>
+        /// Sets the value of a given key.
+        /// </summary>
+        /// <param name="counterId">The ID of the counter to set.</param>
+        /// <param name="count">The new value for the counter.</param>
+        public static void SetCount(int counterId, long count) => Interlocked.Exchange(ref GetOrAddCounter(counterId).Value, count);
+
+        /// <summary>
+        /// Sets the value of a given key.
+        /// </summary>
+        /// <param name="counterId">The ID of the counter to set.</param>
+        /// <param name="value">The value associated with the counter.</param>
+        /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
+        /// <param name="count">The new value for the counter.</param>
+        public static void SetCount(int counterId, int value, bool mapValue, long count) => Interlocked.Exchange(ref GetOrAddCounter(EncodeKey(counterId, value, mapValue)).Value, count);
+        
         /// <summary>
         /// Gets a string with the current cache performance metrics.
         /// It intelligently separates simple counters from histogram data based on key prefixes.

--- a/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/LightweightTrace.cs
+++ b/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/LightweightTrace.cs
@@ -47,6 +47,30 @@ namespace Datacute.IncrementalGeneratorExtensions
         private static readonly (long, int)[] Events = new (long, int)[Capacity];
         private static int _index;
 
+        private static Dictionary<int, string> _customEventNames;
+        private static readonly ConcurrentDictionary<int, string> _dynamicEventNames = new ConcurrentDictionary<int, string>();
+        private static int _nextId = 1024;
+
+        /// <summary>
+        /// Supplies the custom event name map containing pipeline stages and descriptions ahead of time.
+        /// </summary>
+        /// <param name="eventNameMap">The custom event name map.</param>
+        public static void SetEventNameMap(Dictionary<int, string> eventNameMap)
+        {
+            _customEventNames = eventNameMap;
+        }
+
+        /// <summary>
+        /// Dynamically registers a name and returns a unique ID mapping to it.
+        /// </summary>
+        /// <param name="name">The name to register.</param>
+        /// <returns>A unique ID representing the registered name.</returns>
+        public static int RegisterName(string name)
+        {
+            var id = Interlocked.Increment(ref _nextId);
+            _dynamicEventNames[id] = name;
+            return id;
+        }
         /// <summary>
         /// Adds an event to the trace log with the specified event ID.
         /// </summary>
@@ -182,7 +206,7 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// <typeparam name="TEnum">The type of the counter ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
         /// <example>
         /// <code lang="csharp">
-        /// LightweightTrace.IncrementCount(GeneratorStage.EquatableImmutableArrayLength, values.Length);
+        /// LightweightTrace.IncrementCount(GeneratorStage.EquatableImmutableArrayInstanceCacheSize, TypeMapId, true);
         /// LightweightTrace.IncrementCount(GeneratorStage.MethodCall, eventId, true);
         /// </code>
         /// </example>
@@ -290,25 +314,21 @@ namespace Datacute.IncrementalGeneratorExtensions
         {
             DecodeKey(key, out var id, out var value, out var mapped);
 
-            string idText = null;
-            if (eventNameMap != null)
-            {
-                eventNameMap.TryGetValue(id, out idText);
-            }
+            string idText = GetMappedName(eventNameMap, id);
             if (idText == null)
             {
                 idText = string.Empty;
             }
 
-            if (!mapped && value == 0 && key < CompositeValueShift)
+            if (!mapped && value == 0)
             {
                 return idText;
             }
 
             string valueText = null;
-            if (mapped && eventNameMap != null)
+            if (mapped)
             {
-                eventNameMap.TryGetValue(value, out valueText);
+                valueText = GetMappedName(eventNameMap, value);
             }
 
             if (valueText == null)
@@ -317,6 +337,25 @@ namespace Datacute.IncrementalGeneratorExtensions
             }
 
             return idText.Length == 0 ? valueText : $"{idText} ({valueText})";
+        }
+
+        private static string GetMappedName(Dictionary<int, string> eventNameMap, int id)
+        {
+            string idText = null;
+            if (eventNameMap != null)
+            {
+                eventNameMap.TryGetValue(id, out idText);
+            }
+            if (idText == null && _customEventNames != null)
+            {
+                _customEventNames.TryGetValue(id, out idText);
+            }
+            if (idText == null)
+            {
+                _dynamicEventNames.TryGetValue(id, out idText);
+            }
+
+            return idText;
         }
 
         /// <summary>

--- a/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/LightweightTrace.cs
+++ b/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/LightweightTrace.cs
@@ -12,7 +12,7 @@ namespace Datacute.IncrementalGeneratorExtensions
     /// <summary>
     /// Zero-allocation instrumentation core for incremental source generators.
     /// <para>Features: ring-buffer timestamped event trace; composite-key counters (id + value + mapping flag) for histograms & categorical counts; automatic method-call frequency counting; method entry/exit tagging; single-int key encoding to minimize memory & dictionary churn; unified AppendDiagnosticsComment output (counters + trace) embeddable in generated code.</para>
-    /// <para>Goal: fast, in-process behavioral visibility without external profilers or large allocations.</para>
+    /// <para>Goal: fast, in-process behavioural visibility without external profilers or large allocations.</para>
     /// </summary>
     public static class LightweightTrace
     {
@@ -47,30 +47,56 @@ namespace Datacute.IncrementalGeneratorExtensions
         private static readonly (long, int)[] Events = new (long, int)[Capacity];
         private static int _index;
 
+        /// <summary>
+        /// Custom names supplied by the caller for event IDs and mapped values.
+        /// </summary>
+        /// <remarks>
+        /// Used for known names wired by the generator, such as stage descriptions.
+        /// Lookup precedence is: the map passed to the formatting call, then this map (set via <see cref="SetCustomEventNames"/>), then dynamically registered names.
+        /// </remarks>
         private static Dictionary<int, string> _customEventNames;
-        private static readonly ConcurrentDictionary<int, string> _dynamicEventNames = new ConcurrentDictionary<int, string>();
-        private static int _nextId = 1024;
 
         /// <summary>
-        /// Supplies the custom event name map containing pipeline stages and descriptions ahead of time.
+        /// Runtime-registered names keyed by allocated IDs.
         /// </summary>
-        /// <param name="eventNameMap">The custom event name map.</param>
-        public static void SetEventNameMap(Dictionary<int, string> eventNameMap)
+        private static readonly ConcurrentDictionary<int, string> _dynamicValueNames = new ConcurrentDictionary<int, string>();
+
+        /// <summary>
+        /// Backing counter for dynamically registered names.
+        /// </summary>
+        /// <remarks>
+        /// Starts one below <see cref="CompositeValueShift"/> so the first allocated ID enters the dynamic ID range.
+        /// </remarks>
+        private static int _nextId = CompositeValueShift - 1;
+
+        /// <summary>
+        /// Supplies custom names for known event IDs and mapped values.
+        /// </summary>
+        /// <param name="customEventNames">The custom name map.</param>
+        /// <remarks>
+        /// Use this for known names that are available at wiring time.
+        /// </remarks>
+        public static void SetCustomEventNames(Dictionary<int, string> customEventNames)
         {
-            _customEventNames = eventNameMap;
+            _customEventNames = customEventNames;
         }
 
         /// <summary>
-        /// Dynamically registers a name and returns a unique ID mapping to it.
+        /// Dynamically registers a mapped-value name and returns a unique ID for it.
         /// </summary>
         /// <param name="name">The name to register.</param>
-        /// <returns>A unique ID representing the registered name.</returns>
+        /// <returns>A unique ID representing the registered mapped value name.</returns>
+        /// <remarks>
+        /// IDs are allocated from the contiguous range above <see cref="CompositeValueShift"/> and are thread-safe.
+        /// This is typically used for runtime-discovered names such as generic type names.
+        /// </remarks>
         public static int RegisterName(string name)
         {
             var id = Interlocked.Increment(ref _nextId);
-            _dynamicEventNames[id] = name;
+            _dynamicValueNames[id] = name;
             return id;
         }
+
         /// <summary>
         /// Adds an event to the trace log with the specified event ID.
         /// </summary>
@@ -83,7 +109,7 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// Adds an event to the trace log with the specified event ID and numeric value.
         /// </summary>
         /// <param name="eventId">The ID of the event to log.</param>
-        /// <param name="value">The value associated with the event, which can be used for additional context or categorization.</param>
+        /// <param name="value">The value associated with the event, which can be used for additional context or categorisation.</param>
         /// <typeparam name="TEnum">The type of the event ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
         public static void Add<TEnum>(TEnum eventId, int value) where TEnum : Enum
             => Add(System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref eventId), value);
@@ -92,7 +118,7 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// Adds an event to the trace log with the specified event ID and enum value.
         /// </summary>
         /// <param name="eventId">The ID of the event to log.</param>
-        /// <param name="value">The value associated with the event, which can be used for additional context or categorization.</param>
+        /// <param name="value">The value associated with the event, which can be used for additional context or categorisation.</param>
         /// <typeparam name="TEnumKey">The type of the event ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
         /// <typeparam name="TEnumValue">The type of the value, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
         public static void Add<TEnumKey, TEnumValue>(TEnumKey eventId, TEnumValue value)
@@ -104,7 +130,7 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// Adds an event to the trace log with the specified numeric event ID and value.
         /// </summary>
         /// <param name="eventId">The ID of the event to log.</param>
-        /// <param name="value">The value associated with the event, which can be used for additional context or categorization.</param>
+        /// <param name="value">The value associated with the event, which can be used for additional context or categorisation.</param>
         /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
         public static void Add(int eventId, int value, bool mapValue = false) => Add(EncodeKey(eventId, value, mapValue));
 
@@ -147,7 +173,10 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// Appends the trace log to the provided StringBuilder.
         /// </summary>
         /// <param name="stringBuilder">The StringBuilder to append the trace log to.</param>
-        /// <param name="eventNameMap">A dictionary mapping event IDs and values to their names, used for more readable output.</param>
+        /// <param name="eventNameMap">An optional per-call name map for event IDs and mapped values.</param>
+        /// <remarks>
+        /// Name lookup precedence is: the per-call map, then <see cref="SetCustomEventNames"/>, then <see cref="RegisterName"/> registrations.
+        /// </remarks>
         public static void AppendTrace(this StringBuilder stringBuilder, Dictionary<int, string> eventNameMap = null)
         {
             if (stringBuilder is null)
@@ -201,7 +230,7 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// Increments the value of a given key[value] combination by 1.
         /// </summary>
         /// <param name="counterId">The ID of the counter to increment.</param>
-        /// <param name="value">The value associated with the counter, which can be used for additional context or categorization.</param>
+        /// <param name="value">The value associated with the counter, which can be used for additional context or categorisation.</param>
         /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
         /// <typeparam name="TEnum">The type of the counter ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
         /// <example>
@@ -225,7 +254,7 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// Decrements the value of a given key[value] combination by 1.
         /// </summary>
         /// <param name="counterId">The ID of the counter to decrement.</param>
-        /// <param name="value">The value associated with the counter, which can be used for additional context or categorization.</param>
+        /// <param name="value">The value associated with the counter, which can be used for additional context or categorisation.</param>
         /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
         /// <typeparam name="TEnum">The type of the counter ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
         public static void DecrementCount<TEnum>(TEnum counterId, int value, bool mapValue = false) where TEnum : Enum
@@ -244,7 +273,7 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// Sets the value of a given key.
         /// </summary>
         /// <param name="counterId">The ID of the counter to set.</param>
-        /// <param name="value">The value associated with the counter, which can be used for additional context or categorization.</param>
+        /// <param name="value">The value associated with the counter, which can be used for additional context or categorisation.</param>
         /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
         /// <param name="count">The new value for the counter.</param>
         /// <typeparam name="TEnum">The type of the counter ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
@@ -261,21 +290,21 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// Increments the value of a given key[value] combination by 1.
         /// </summary>
         /// <param name="counterId">The ID of the counter to increment.</param>
-        /// <param name="value">The value associated with the counter, which can be used for additional context or categorization.</param>
+        /// <param name="value">The value associated with the counter, which can be used for additional context or categorisation.</param>
         /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
         public static void IncrementCount(int counterId, int value, bool mapValue = false) => Interlocked.Increment(ref GetOrAddCounter(EncodeKey(counterId, value, mapValue)).Value);
 
         /// <summary>
         /// Decrements the value of a given key by 1.
         /// </summary>
-        /// <param name="counterId">The ID of the counter to increment.</param>
+        /// <param name="counterId">The ID of the counter to decrement.</param>
         public static void DecrementCount(int counterId) => Interlocked.Decrement(ref GetOrAddCounter(counterId).Value);
 
         /// <summary>
         /// Decrements the value of a given key[value] combination by 1.
         /// </summary>
         /// <param name="counterId">The ID of the counter to decrement.</param>
-        /// <param name="value">The value associated with the counter, which can be used for additional context or categorization.</param>
+        /// <param name="value">The value associated with the counter, which can be used for additional context or categorisation.</param>
         /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
         public static void DecrementCount(int counterId, int value, bool mapValue = false) => Interlocked.Decrement(ref GetOrAddCounter(EncodeKey(counterId, value, mapValue)).Value);
 
@@ -388,7 +417,7 @@ namespace Datacute.IncrementalGeneratorExtensions
             }
             if (idText == null)
             {
-                _dynamicEventNames.TryGetValue(id, out idText);
+                _dynamicValueNames.TryGetValue(id, out idText);
             }
 
             return idText;

--- a/benchmarks/IncrementalGeneratorExtensions.Benchmarks/EquatableImmutableArrayBenchmarks.cs
+++ b/benchmarks/IncrementalGeneratorExtensions.Benchmarks/EquatableImmutableArrayBenchmarks.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 
 namespace Datacute.IncrementalGeneratorExtensions.Benchmarks
@@ -45,9 +44,26 @@ namespace Datacute.IncrementalGeneratorExtensions.Benchmarks
         private EquatableImmutableArray<TypeContext> _longA = null!;
         private EquatableImmutableArray<TypeContext> _longB = null!;    // different values → different hash
 
+        private const int OpsEqualsSame = 400_000_000;
+        private const int OpsEqualsDiff = 200_000_000;
+        private const int OpsHashCode = 500_000_000;
+
         [GlobalSetup]
         public void Setup()
         {
+            _shortA = EquatableImmutableArray<TypeContext>.Create(ImmutableArrayFactory.BuildShort(1, 2, 3));
+            _shortB = EquatableImmutableArray<TypeContext>.Create(ImmutableArrayFactory.BuildShort(10, 20, 30));
+
+            _longA = EquatableImmutableArray<TypeContext>.Create(ImmutableArrayFactory.BuildAscending(20));
+            _longB = EquatableImmutableArray<TypeContext>.Create(ImmutableArrayFactory.BuildDescending(20));
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            EquatableImmutableArrayInstanceCache<TypeContext>.Clear();
+            
+            // Re-populate the cache
             _shortA = EquatableImmutableArray<TypeContext>.Create(ImmutableArrayFactory.BuildShort(1, 2, 3));
             _shortB = EquatableImmutableArray<TypeContext>.Create(ImmutableArrayFactory.BuildShort(10, 20, 30));
 
@@ -60,73 +76,118 @@ namespace Datacute.IncrementalGeneratorExtensions.Benchmarks
         // ------------------------------------------------------------------ //
 
         /// <summary>Reference-equality short-circuit on a 3-element array.</summary>
-        [Benchmark]
-        public bool Equals_SameInstance_Short() => _shortA.Equals(_shortA);
+        [Benchmark(OperationsPerInvoke = OpsEqualsSame)]
+        public bool Equals_SameInstance_Short()
+        {
+            bool result = false;
+            for (int i = 0; i < OpsEqualsSame; i++)
+            {
+                result = _shortA.Equals(_shortA);
+            }
+            return result;
+        }
 
         /// <summary>Reference-equality short-circuit on a 20-element array.</summary>
-        [Benchmark]
-        public bool Equals_SameInstance_Long() => _longA.Equals(_longA);
+        [Benchmark(OperationsPerInvoke = OpsEqualsSame)]
+        public bool Equals_SameInstance_Long()
+        {
+            bool result = false;
+            for (int i = 0; i < OpsEqualsSame; i++)
+            {
+                result = _longA.Equals(_longA);
+            }
+            return result;
+        }
 
         // ------------------------------------------------------------------ //
         //  Equals — hash-code mismatch (fast rejection, no element scan)      //
         // ------------------------------------------------------------------ //
 
         /// <summary>Hash-mismatch early exit on a 3-element array.</summary>
-        [Benchmark]
-        public bool Equals_DifferentHashCode_Short() => _shortA.Equals(_shortB);
+        [Benchmark(OperationsPerInvoke = OpsEqualsDiff)]
+        public bool Equals_DifferentHashCode_Short()
+        {
+            bool result = false;
+            for (int i = 0; i < OpsEqualsDiff; i++)
+            {
+                result = _shortA.Equals(_shortB);
+            }
+            return result;
+        }
 
         /// <summary>Hash-mismatch early exit on a 20-element array.</summary>
-        [Benchmark]
-        public bool Equals_DifferentHashCode_Long() => _longA.Equals(_longB);
+        [Benchmark(OperationsPerInvoke = OpsEqualsDiff)]
+        public bool Equals_DifferentHashCode_Long()
+        {
+            bool result = false;
+            for (int i = 0; i < OpsEqualsDiff; i++)
+            {
+                result = _longA.Equals(_longB);
+            }
+            return result;
+        }
 
         // ------------------------------------------------------------------ //
         //  GetHashCode — returns cached field                                 //
         // ------------------------------------------------------------------ //
 
         /// <summary>Returns the pre-computed hash stored in the instance (3-element array).</summary>
-        [Benchmark]
-        public int GetHashCode_Short() => _shortA.GetHashCode();
+        [Benchmark(OperationsPerInvoke = OpsHashCode)]
+        public int GetHashCode_Short()
+        {
+            int result = 0;
+            for (int i = 0; i < OpsHashCode; i++)
+            {
+                result = _shortA.GetHashCode();
+            }
+            return result;
+        }
 
         /// <summary>Returns the pre-computed hash stored in the instance (20-element array).</summary>
-        [Benchmark]
-        public int GetHashCode_Long() => _longA.GetHashCode();
+        [Benchmark(OperationsPerInvoke = OpsHashCode)]
+        public int GetHashCode_Long()
+        {
+            int result = 0;
+            for (int i = 0; i < OpsHashCode; i++)
+            {
+                result = _longA.GetHashCode();
+            }
+            return result;
+        }
     }
 }
 
 /*
-BenchmarkDotNet v0.15.1, Windows 11 (10.0.26200.8457)
-12th Gen Intel Core i7-12700H 2.30GHz, 1 CPU, 20 logical and 14 physical cores                                                                                                                              
-.NET SDK 10.0.300                                                                                                                                                                                           
-  [Host] : .NET 10.0.8 (10.0.826.23019), X64 RyuJIT AVX2                                                                                                                                                    
-  net10  : .NET 10.0.8 (10.0.826.23019), X64 RyuJIT AVX2                                                                                                                                                    
-  net481 : .NET Framework 4.8.1 (4.8.9325.0), X64 RyuJIT VectorSize=256                                                                                                                                     
-                                                                                                                                                                                                            
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8524/25H2/2025Update/HudsonValley2)
+12th Gen Intel Core i7-12700H 2.30GHz, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 10.0.300
+  [Host] : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
+  net10  : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
+  net481 : .NET Framework 4.8.1 (4.8.9337.0), X64 RyuJIT VectorSize=256
 
-| Method                         | Job    | Mean       | Error     | StdDev    | Median     | Allocated |
-|------------------------------- |------- |-----------:|----------:|----------:|-----------:|----------:|
-| Equals_DifferentHashCode_Long  | net10  |  0.3700 ns | 0.0341 ns | 0.0444 ns |  0.3713 ns |         - |
-| Equals_DifferentHashCode_Long  | net481 |  9.4795 ns | 0.1355 ns | 0.1201 ns |  9.4434 ns |         - |
-| Equals_DifferentHashCode_Short | net10  |  0.2715 ns | 0.0305 ns | 0.0299 ns |  0.2731 ns |         - |
-| Equals_DifferentHashCode_Short | net481 |  9.4793 ns | 0.0786 ns | 0.0735 ns |  9.4524 ns |         - |
-| Equals_SameInstance_Long       | net10  |  0.0022 ns | 0.0056 ns | 0.0052 ns |  0.0000 ns |         - |
-| Equals_SameInstance_Long       | net481 | 13.6385 ns | 0.1473 ns | 0.1306 ns | 13.6192 ns |         - |
-| Equals_SameInstance_Short      | net10  |  0.0146 ns | 0.0194 ns | 0.0181 ns |  0.0042 ns |         - |
-| Equals_SameInstance_Short      | net481 |  9.5169 ns | 0.0820 ns | 0.0767 ns |  9.5437 ns |         - |
-| GetHashCode_Long               | net10  |  0.0054 ns | 0.0085 ns | 0.0071 ns |  0.0020 ns |         - |
-| GetHashCode_Long               | net481 |  0.0002 ns | 0.0006 ns | 0.0005 ns |  0.0000 ns |         - |
-| GetHashCode_Short              | net10  |  0.0204 ns | 0.0239 ns | 0.0223 ns |  0.0192 ns |         - |
-| GetHashCode_Short              | net481 |  0.0000 ns | 0.0000 ns | 0.0000 ns |  0.0000 ns |         - |
+InvocationCount=1  UnrollFactor=1
+
+| Method                         | Job    | Mean       | Error     | StdDev    | Allocated |
+|------------------------------- |------- |-----------:|----------:|----------:|----------:|
+| Equals_DifferentHashCode_Long  | net10  |  0.4497 ns | 0.0089 ns | 0.0158 ns |         - |
+| Equals_DifferentHashCode_Long  | net481 |  8.8106 ns | 0.1403 ns | 0.1244 ns |         - |
+| Equals_DifferentHashCode_Short | net10  |  0.4426 ns | 0.0084 ns | 0.0087 ns |         - |
+| Equals_DifferentHashCode_Short | net481 |  8.7547 ns | 0.1095 ns | 0.1025 ns |         - |
+| Equals_SameInstance_Long       | net10  |  0.2364 ns | 0.0032 ns | 0.0029 ns |         - |
+| Equals_SameInstance_Long       | net481 |  8.6131 ns | 0.1268 ns | 0.1059 ns |         - |
+| Equals_SameInstance_Short      | net10  |  0.2372 ns | 0.0040 ns | 0.0041 ns |         - |
+| Equals_SameInstance_Short      | net481 | 17.5429 ns | 0.1368 ns | 0.1280 ns |         - |
+| GetHashCode_Long               | net10  |  0.2192 ns | 0.0032 ns | 0.0028 ns |         - |
+| GetHashCode_Long               | net481 |  0.2190 ns | 0.0020 ns | 0.0018 ns |         - |
+| GetHashCode_Short              | net10  |  0.2253 ns | 0.0044 ns | 0.0064 ns |         - |
+| GetHashCode_Short              | net481 |  0.2214 ns | 0.0033 ns | 0.0043 ns |         - |
 
 // * Warnings *
-ZeroMeasurement
-  EquatableImmutableArrayBenchmarks.Equals_SameInstance_Long: net10  -> The method duration is indistinguishable from the empty method duration
-  EquatableImmutableArrayBenchmarks.Equals_SameInstance_Short: net10 -> The method duration is indistinguishable from the empty method duration
-  EquatableImmutableArrayBenchmarks.GetHashCode_Long: net10          -> The method duration is indistinguishable from the empty method duration
-  EquatableImmutableArrayBenchmarks.GetHashCode_Long: net481         -> The method duration is indistinguishable from the empty method duration
-  EquatableImmutableArrayBenchmarks.GetHashCode_Short: net10         -> The method duration is indistinguishable from the empty method duration
-  EquatableImmutableArrayBenchmarks.GetHashCode_Short: net481        -> The method duration is indistinguishable from the empty method duration
-MultimodalDistribution
-  EquatableImmutableArrayBenchmarks.Equals_DifferentHashCode_Long: net10  -> It seems that the distribution can have several modes (mValue = 3.11)
-  EquatableImmutableArrayBenchmarks.Equals_DifferentHashCode_Short: net10 -> It seems that the distribution can have several modes (mValue = 2.89)
+MinIterationTime
+  EquatableImmutableArrayBenchmarks.Equals_DifferentHashCode_Long: net10  -> The minimum observed iteration time is 86.679ms which is very small. It's recommended to increase it to at least 100ms using more operations.
+  EquatableImmutableArrayBenchmarks.Equals_DifferentHashCode_Short: net10 -> The minimum observed iteration time is 86.764ms which is very small. It's recommended to increase it to at least 100ms using more operations.
+  EquatableImmutableArrayBenchmarks.Equals_SameInstance_Long: net10       -> The minimum observed iteration time is 93.033ms which is very small. It's recommended to increase it to at least 100ms using more operations.
+  EquatableImmutableArrayBenchmarks.Equals_SameInstance_Short: net10      -> The minimum observed iteration time is 93.284ms which is very small. It's recommended to increase it to at least 100ms using more operations.
+
 
 */

--- a/benchmarks/IncrementalGeneratorExtensions.Benchmarks/EquatableImmutableArrayCreateBenchmarks.cs
+++ b/benchmarks/IncrementalGeneratorExtensions.Benchmarks/EquatableImmutableArrayCreateBenchmarks.cs
@@ -35,6 +35,11 @@ namespace Datacute.IncrementalGeneratorExtensions.Benchmarks
         private EquatableImmutableArray<TypeContext> _prevShort;
         private EquatableImmutableArray<TypeContext> _prevLong;
 
+        private const int OpsCachedShort = 5_000_000;
+        private const int OpsCachedLong = 2_000_000;
+        private const int OpsNoCacheShort = 2_500_000;
+        private const int OpsNoCacheLong = 300_000;
+
         [GlobalSetup]
         public void Setup()
         {
@@ -46,22 +51,42 @@ namespace Datacute.IncrementalGeneratorExtensions.Benchmarks
             _prevLong = EquatableImmutableArray<TypeContext>.Create(_rawLong);
         }
 
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            EquatableImmutableArrayInstanceCache<TypeContext>.Clear();
+            
+            // Re-populate the cache
+            _prevShort = EquatableImmutableArray<TypeContext>.Create(_rawShort);
+            _prevLong = EquatableImmutableArray<TypeContext>.Create(_rawLong);
+        }
+
         // ------------------------------------------------------------------ //
         //  Cached: Create via instance cache, then Equals against previous      //
         // ------------------------------------------------------------------ //
 
-        [Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true, OperationsPerInvoke = OpsCachedShort)]
         public bool Cached_CreateThenEquals_Short()
         {
-            var created = EquatableImmutableArray<TypeContext>.Create(_rawShort);
-            return created.Equals(_prevShort);
+            bool result = false;
+            for (int i = 0; i < OpsCachedShort; i++)
+            {
+                var created = EquatableImmutableArray<TypeContext>.Create(_rawShort);
+                result = created.Equals(_prevShort);
+            }
+            return result;
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = OpsCachedLong)]
         public bool Cached_CreateThenEquals_Long()
         {
-            var created = EquatableImmutableArray<TypeContext>.Create(_rawLong);
-            return created.Equals(_prevLong);
+            bool result = false;
+            for (int i = 0; i < OpsCachedLong; i++)
+            {
+                var created = EquatableImmutableArray<TypeContext>.Create(_rawLong);
+                result = created.Equals(_prevLong);
+            }
+            return result;
         }
 
         // ------------------------------------------------------------------ //
@@ -72,45 +97,55 @@ namespace Datacute.IncrementalGeneratorExtensions.Benchmarks
         /// Creates a new instance without the cache, as <see cref="EquatableImmutableArray{T}.Create"/>
         /// does when <c>DATACUTE_EXCLUDE_EQUATABLEIMMUTABLEARRAYINSTANCECACHE</c> is defined.
         /// </summary>
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = OpsNoCacheShort)]
         public bool NoCache_CreateThenEquals_Short()
         {
-            var comparer = EqualityComparer<TypeContext>.Default;
-            int hash = EquatableImmutableArray<TypeContext>.CalculateHashCode(_rawShort, comparer, 0, 0);
-            var created = new EquatableImmutableArray<TypeContext>(_rawShort, hash);
-            return created.Equals(_prevShort);
+            bool result = false;
+            for (int i = 0; i < OpsNoCacheShort; i++)
+            {
+                var comparer = EqualityComparer<TypeContext>.Default;
+                int hash = EquatableImmutableArray<TypeContext>.CalculateHashCode(_rawShort, comparer, 0, 0);
+                var created = new EquatableImmutableArray<TypeContext>(_rawShort, hash);
+                result = created.Equals(_prevShort);
+            }
+            return result;
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = OpsNoCacheLong)]
         public bool NoCache_CreateThenEquals_Long()
         {
-            var comparer = EqualityComparer<TypeContext>.Default;
-            int hash = EquatableImmutableArray<TypeContext>.CalculateHashCode(_rawLong, comparer, 0, 0);
-            var created = new EquatableImmutableArray<TypeContext>(_rawLong, hash);
-            return created.Equals(_prevLong);
+            bool result = false;
+            for (int i = 0; i < OpsNoCacheLong; i++)
+            {
+                var comparer = EqualityComparer<TypeContext>.Default;
+                int hash = EquatableImmutableArray<TypeContext>.CalculateHashCode(_rawLong, comparer, 0, 0);
+                var created = new EquatableImmutableArray<TypeContext>(_rawLong, hash);
+                result = created.Equals(_prevLong);
+            }
+            return result;
         }
     }
 }
 
 /*
-BenchmarkDotNet v0.15.1, Windows 11 (10.0.26200.8457)
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8457/25H2/2025Update/HudsonValley2)
 12th Gen Intel Core i7-12700H 2.30GHz, 1 CPU, 20 logical and 14 physical cores
 .NET SDK 10.0.300
-  [Host] : .NET 10.0.8 (10.0.826.23019), X64 RyuJIT AVX2
-  net10  : .NET 10.0.8 (10.0.826.23019), X64 RyuJIT AVX2
+  [Host] : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
+  net10  : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
   net481 : .NET Framework 4.8.1 (4.8.9325.0), X64 RyuJIT VectorSize=256
 
-| Method                         | Job    | Mean      | Error     | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
-|------------------------------- |------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
-| Cached_CreateThenEquals_Long   | net10  |  94.09 ns |  1.818 ns |  1.785 ns |  2.98 |    0.06 |      - |         - |          NA |
-| Cached_CreateThenEquals_Long   | net481 | 200.99 ns |  2.268 ns |  2.122 ns |  2.64 |    0.04 |      - |         - |          NA |
-| Cached_CreateThenEquals_Short  | net10  |  31.62 ns |  0.319 ns |  0.267 ns |  1.00 |    0.01 |      - |         - |          NA |
-| Cached_CreateThenEquals_Short  | net481 |  76.01 ns |  0.751 ns |  0.703 ns |  1.00 |    0.01 |      - |         - |          NA |
-| NoCache_CreateThenEquals_Long  | net10  | 381.61 ns |  4.086 ns |  3.190 ns | 12.07 |    0.14 |      - |         - |          NA |
-| NoCache_CreateThenEquals_Long  | net481 | 561.52 ns | 10.923 ns | 11.217 ns |  7.39 |    0.16 | 0.0048 |      32 B |          NA |
-| NoCache_CreateThenEquals_Short | net10  |  58.51 ns |  0.462 ns |  0.409 ns |  1.85 |    0.02 |      - |         - |          NA |
-| NoCache_CreateThenEquals_Short | net481 |  97.28 ns |  1.439 ns |  1.346 ns |  1.28 |    0.02 | 0.0050 |      32 B |          NA |
+InvocationCount=1  UnrollFactor=1  
+
+| Method                         | Job    | Mean      | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|------------------------------- |------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+| Cached_CreateThenEquals_Long   | net10  |  89.48 ns | 1.051 ns | 0.932 ns |  2.90 |    0.07 |      - |         - |          NA |
+| Cached_CreateThenEquals_Long   | net481 | 202.10 ns | 3.539 ns | 3.310 ns |  2.70 |    0.06 |      - |         - |          NA |
+| Cached_CreateThenEquals_Short  | net10  |  30.84 ns | 0.608 ns | 0.700 ns |  1.00 |    0.03 |      - |         - |          NA |
+| Cached_CreateThenEquals_Short  | net481 |  74.73 ns | 1.152 ns | 1.078 ns |  1.00 |    0.02 |      - |         - |          NA |
+| NoCache_CreateThenEquals_Long  | net10  | 398.01 ns | 2.787 ns | 2.176 ns | 12.91 |    0.29 |      - |      32 B |          NA |
+| NoCache_CreateThenEquals_Long  | net481 | 542.56 ns | 6.118 ns | 5.723 ns |  7.26 |    0.13 | 0.0033 |      32 B |          NA |
+| NoCache_CreateThenEquals_Short | net10  |  64.72 ns | 1.261 ns | 1.595 ns |  2.10 |    0.07 | 0.0024 |      32 B |          NA |
+| NoCache_CreateThenEquals_Short | net481 |  93.22 ns | 0.669 ns | 0.626 ns |  1.25 |    0.02 | 0.0048 |      32 B |          NA |
 
 */
-
-

--- a/benchmarks/IncrementalGeneratorExtensions.Benchmarks/EquatableImmutableArrayInstanceCacheBenchmarks.cs
+++ b/benchmarks/IncrementalGeneratorExtensions.Benchmarks/EquatableImmutableArrayInstanceCacheBenchmarks.cs
@@ -8,18 +8,18 @@ namespace Datacute.IncrementalGeneratorExtensions.Benchmarks
     /// Benchmarks for <see cref="EquatableImmutableArrayInstanceCache{T}.GetOrCreate"/>.
     /// </summary>
     /// <remarks>
-    /// Three distinct scenarios are measured:
+    /// Scenarios are closely aligned to the two-level cache structure:
     /// <list type="bullet">
     ///   <item>Empty array — returns the shared singleton immediately.</item>
-    ///   <item>Cache hit — every call returns an already-cached instance; exercises the
-    ///       lock-free lookup through length → first-element-hash → element comparison.</item>
-    ///   <item>Cache miss — a monotonically-increasing first element guarantees a new bucket
-    ///       on every call; measures allocation + insertion cost.  The cache grows continuously
-    ///       during this benchmark; GC pressure is visible in the allocation column.</item>
+    ///   <item>MRU Hit — immediately returns from the lock-free strong reference hot path.</item>
+    ///   <item>Dictionary Hit — misses the MRU (using a pool larger than MRU size) but finds the instance via dictionary lookup.</item>
+    ///   <item>Miss (Unique) — unique first element produces a new MRU slot and new dictionary bucket every call.</item>
+    ///   <item>Miss (Tail Varies) — a typical miss scenario. Same first element forces an MRU element check (fail), but a unique last element creates a new dictionary bucket.</item>
+    ///   <item>Miss (Middle Varies) — forces dictionary bucket collisions since the first/last elements are identical, exercising inline weak reference list scanning.</item>
     /// </list>
     /// </remarks>
     [MemoryDiagnoser]
-    [HideColumns("Runtime", "IterationCount", "WarmupCount")]
+    [HideColumns("Runtime")]
     [BenchmarkCategory("EquatableImmutableArrayInstanceCache")]
     [SimpleJob(RuntimeMoniker.Net481, id: "net481")]
     [SimpleJob(RuntimeMoniker.Net10_0, id: "net10")]
@@ -31,8 +31,25 @@ namespace Datacute.IncrementalGeneratorExtensions.Benchmarks
         private ImmutableArray<TypeContext> _warmShort;
         private ImmutableArray<TypeContext> _warmLong;
 
+        // Pools to guarantee MRU eviction but Dictionary hits
+        private ImmutableArray<ImmutableArray<TypeContext>> _dictPoolShort;
+        private ImmutableArray<ImmutableArray<TypeContext>> _dictPoolLong;
+        private const int PoolSize = 256;
+
         // Counter used to produce a brand-new first element on every cache-miss call.
         private int _missCounter;
+
+        private const int OpsEmpty = 25_000_000;
+        private const int OpsMruHitShort = 4_000_000;
+        private const int OpsMruHitLong = 1_500_000;
+        private const int OpsDictHitShort = 2_000_000;
+        private const int OpsDictHitLong = 1_000_000;
+        private const int OpsMissUniqueShort = 200_000;
+        private const int OpsMissUniqueLong = 65_000;
+        private const int OpsMissTailVariesShort = 100_000;
+        private const int OpsMissTailVariesLong = 55_000;
+        private const int OpsMissMiddleVariesShort = 20_000;
+        private const int OpsMissMiddleVariesLong = 2_000;
 
         [GlobalSetup]
         public void Setup()
@@ -40,11 +57,37 @@ namespace Datacute.IncrementalGeneratorExtensions.Benchmarks
             _warmShort = ImmutableArrayFactory.BuildAscending(3);
             _warmLong = ImmutableArrayFactory.BuildAscending(20);
 
+            var shortPool = ImmutableArray.CreateBuilder<ImmutableArray<TypeContext>>(PoolSize);
+            var longPool = ImmutableArray.CreateBuilder<ImmutableArray<TypeContext>>(PoolSize);
+            for (int i = 0; i < PoolSize; i++)
+            {
+                shortPool.Add(ImmutableArrayFactory.BuildShort(1000 + i, 42, 99));
+                longPool.Add(ImmutableArrayFactory.BuildWithUniqueFirstElement(20, 1000 + i));
+            }
+            _dictPoolShort = shortPool.ToImmutable();
+            _dictPoolLong = longPool.ToImmutable();
+
             // Pre-populate the cache so subsequent hits are truly warm.
             EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(_warmShort);
             EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(_warmLong);
+            foreach (var arr in _dictPoolShort) EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(arr);
+            foreach (var arr in _dictPoolLong) EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(arr);
 
             _missCounter = 1_000_000; // start well away from the warm arrays
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            EquatableImmutableArrayInstanceCache<TypeContext>.Clear();
+            
+            // Re-populate the cache
+            EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(_warmShort);
+            EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(_warmLong);
+            foreach (var arr in _dictPoolShort) EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(arr);
+            foreach (var arr in _dictPoolLong) EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(arr);
+            
+            _missCounter = 1_000_000;
         }
 
         // ------------------------------------------------------------------ //
@@ -52,118 +95,212 @@ namespace Datacute.IncrementalGeneratorExtensions.Benchmarks
         // ------------------------------------------------------------------ //
 
         /// <summary>Returns <see cref="EquatableImmutableArray{T}.Empty"/> via the fast-path guard.</summary>
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = OpsEmpty)]
         public EquatableImmutableArray<TypeContext> GetOrCreate_Empty()
-            => EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(EmptyArray);
-
-        // ------------------------------------------------------------------ //
-        //  Cache hit                                                           //
-        // ------------------------------------------------------------------ //
-
-        /// <summary>Cache hit for a 3-element array.</summary>
-        [Benchmark]
-        public EquatableImmutableArray<TypeContext> GetOrCreate_CacheHit_Short()
-            => EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(_warmShort);
-
-        /// <summary>Cache hit for a 20-element array.</summary>
-        [Benchmark]
-        public EquatableImmutableArray<TypeContext> GetOrCreate_CacheHit_Long()
-            => EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(_warmLong);
-
-        // ------------------------------------------------------------------ //
-        //  Cache miss                                                          //
-        // ------------------------------------------------------------------ //
-
-        /// <summary>
-        /// Cache miss: a unique first element on every call means the cache will never find a
-        /// match, so a new <see cref="EquatableImmutableArray{T}"/> is allocated and inserted each time.
-        /// </summary>
-        /// <remarks>Bounded to 15 iterations to keep total run time manageable; the sweep cost
-        /// makes individual iterations expensive and highly variable.</remarks>
-        [Benchmark]
-        [WarmupCount(3), IterationCount(15)]
-        public EquatableImmutableArray<TypeContext> GetOrCreate_CacheMiss_Short()
         {
-            var arr = ImmutableArrayFactory.BuildShort(_missCounter++, 42, 99);
-            return EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(arr);
-        }
-
-        /// <summary>Cache miss for a 20-element array.</summary>
-        /// <remarks>Bounded to 15 iterations to keep total run time manageable.</remarks>
-        [Benchmark]
-        [WarmupCount(3), IterationCount(15)]
-        public EquatableImmutableArray<TypeContext> GetOrCreate_CacheMiss_Long()
-        {
-            return EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(ImmutableArrayFactory.BuildWithUniqueFirstElement(20, _missCounter++));
+            EquatableImmutableArray<TypeContext> result = null;
+            for (int i = 0; i < OpsEmpty; i++)
+            {
+                result = EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(EmptyArray);
+            }
+            return result;
         }
 
         // ------------------------------------------------------------------ //
-        //  Cache miss — tail varies (same first element, unique last element) //
-        //  All entries collide into the same candidateList bucket, so the     //
-        //  linear scan grows O(n) with each miss: demonstrates the O(n²)     //
-        //  worst case noted in the TODO comment in the implementation.        //
+        //  MRU Hit                                                             //
+        // ------------------------------------------------------------------ //
+
+        /// <summary>MRU cache hit for a 3-element array.</summary>
+        [Benchmark(OperationsPerInvoke = OpsMruHitShort)]
+        public EquatableImmutableArray<TypeContext> GetOrCreate_MruHit_Short()
+        {
+            EquatableImmutableArray<TypeContext> result = null;
+            for (int i = 0; i < OpsMruHitShort; i++)
+            {
+                result = EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(_warmShort);
+            }
+            return result;
+        }
+
+        /// <summary>MRU cache hit for a 20-element array.</summary>
+        [Benchmark(OperationsPerInvoke = OpsMruHitLong)]
+        public EquatableImmutableArray<TypeContext> GetOrCreate_MruHit_Long()
+        {
+            EquatableImmutableArray<TypeContext> result = null;
+            for (int i = 0; i < OpsMruHitLong; i++)
+            {
+                result = EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(_warmLong);
+            }
+            return result;
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Dictionary Hit                                                      //
+        // ------------------------------------------------------------------ //
+
+        /// <summary>Dictionary hit (MRU miss) for 3-element arrays.</summary>
+        [Benchmark(OperationsPerInvoke = OpsDictHitShort)]
+        public EquatableImmutableArray<TypeContext> GetOrCreate_DictHit_Short()
+        {
+            EquatableImmutableArray<TypeContext> result = null;
+            for (int i = 0; i < OpsDictHitShort; i++)
+            {
+                result = EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(_dictPoolShort[i % PoolSize]);
+            }
+            return result;
+        }
+
+        /// <summary>Dictionary hit (MRU miss) for 20-element arrays.</summary>
+        [Benchmark(OperationsPerInvoke = OpsDictHitLong)]
+        public EquatableImmutableArray<TypeContext> GetOrCreate_DictHit_Long()
+        {
+            EquatableImmutableArray<TypeContext> result = null;
+            for (int i = 0; i < OpsDictHitLong; i++)
+            {
+                result = EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(_dictPoolLong[i % PoolSize]);
+            }
+            return result;
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Cache Miss - Unique                                               //
         // ------------------------------------------------------------------ //
 
         /// <summary>
-        /// Cache miss for a 3-element array where only the <em>last</em> element varies.
-        /// Every array shares the same first element hash, so all entries accumulate in a
-        /// single <c>candidateList</c> bucket.  The linear scan grows O(n) with each miss,
-        /// producing O(n²) total work across the benchmark run.
+        /// Cache miss (Unique): unique first element produces a new MRU entry and new dictionary bucket every call.
         /// </summary>
-        /// <remarks>Bounded to 15 iterations to keep total run time manageable.</remarks>
-        [Benchmark]
-        [WarmupCount(3), IterationCount(15)]
-        public EquatableImmutableArray<TypeContext> GetOrCreate_CacheMiss_Short_TailVaries()
+        [Benchmark(OperationsPerInvoke = OpsMissUniqueShort)]
+        public EquatableImmutableArray<TypeContext> GetOrCreate_Miss_Unique_Short()
         {
-            var arr = ImmutableArrayFactory.BuildShort(42, 99, _missCounter++);
-            return EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(arr);
+            EquatableImmutableArray<TypeContext> result = null;
+            for (int i = 0; i < OpsMissUniqueShort; i++)
+            {
+                var arr = ImmutableArrayFactory.BuildShort(_missCounter++, 42, 99);
+                result = EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(arr);
+            }
+            return result;
         }
 
-        /// <summary>
-        /// Cache miss for a 20-element array where only the <em>last</em> element varies.
-        /// Every array shares the same first element hash, so all entries accumulate in a
-        /// single <c>candidateList</c> bucket.  The linear scan grows O(n) with each miss,
-        /// producing O(n²) total work across the benchmark run.
-        /// </summary>
-        /// <remarks>Bounded to 15 iterations to keep total run time manageable.</remarks>
-        [Benchmark]
-        [WarmupCount(3), IterationCount(15)]
-        public EquatableImmutableArray<TypeContext> GetOrCreate_CacheMiss_Long_TailVaries()
+        /// <summary>Cache miss (Unique) for a 20-element array.</summary>
+        [Benchmark(OperationsPerInvoke = OpsMissUniqueLong)]
+        public EquatableImmutableArray<TypeContext> GetOrCreate_Miss_Unique_Long()
         {
-            return EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(ImmutableArrayFactory.BuildWithUniqueLastElement(20, _missCounter++));
+            EquatableImmutableArray<TypeContext> result = null;
+            for (int i = 0; i < OpsMissUniqueLong; i++)
+            {
+                result = EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(ImmutableArrayFactory.BuildWithUniqueFirstElement(20, _missCounter++));
+            }
+            return result;
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Cache Miss - Tail Varies                                          //
+        // ------------------------------------------------------------------ //
+
+        /// <summary>
+        /// Cache miss (Tail Varies): typical scenario where arrays share a prefix. MRU element
+        /// check fails, and the differing last element produces a new dictionary bucket.
+        /// </summary>
+        [Benchmark(OperationsPerInvoke = OpsMissTailVariesShort)]
+        public EquatableImmutableArray<TypeContext> GetOrCreate_Miss_TailVaries_Short()
+        {
+            EquatableImmutableArray<TypeContext> result = null;
+            for (int i = 0; i < OpsMissTailVariesShort; i++)
+            {
+                var arr = ImmutableArrayFactory.BuildShort(42, 99, _missCounter++);
+                result = EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(arr);
+            }
+            return result;
+        }
+
+        /// <summary>Cache miss (Tail Varies) for a 20-element array.</summary>
+        [Benchmark(OperationsPerInvoke = OpsMissTailVariesLong)]
+        public EquatableImmutableArray<TypeContext> GetOrCreate_Miss_TailVaries_Long()
+        {
+            EquatableImmutableArray<TypeContext> result = null;
+            for (int i = 0; i < OpsMissTailVariesLong; i++)
+            {
+                result = EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(ImmutableArrayFactory.BuildWithUniqueLastElement(20, _missCounter++));
+            }
+            return result;
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Cache Miss - Middle Varies (Collisions)                           //
+        // ------------------------------------------------------------------ //
+
+        /// <summary>
+        /// Cache miss (Middle Varies): only the middle element varies, forcing entries into
+        /// the same MRU slot and the exact same Dictionary bucket (since BucketHash relies on first/last).
+        /// </summary>
+        [Benchmark(OperationsPerInvoke = OpsMissMiddleVariesShort)]
+        public EquatableImmutableArray<TypeContext> GetOrCreate_Miss_MiddleVaries_Short()
+        {
+            EquatableImmutableArray<TypeContext> result = null;
+            for (int i = 0; i < OpsMissMiddleVariesShort; i++)
+            {
+                var arr = ImmutableArrayFactory.BuildShort(42, _missCounter++, 99);
+                result = EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(arr);
+            }
+            return result;
+        }
+
+        /// <summary>Cache miss (Middle Varies) for a 20-element array.</summary>
+        [Benchmark(OperationsPerInvoke = OpsMissMiddleVariesLong)]
+        public EquatableImmutableArray<TypeContext> GetOrCreate_Miss_MiddleVaries_Long()
+        {
+            EquatableImmutableArray<TypeContext> result = null;
+            for (int i = 0; i < OpsMissMiddleVariesLong; i++)
+            {
+                result = EquatableImmutableArrayInstanceCache<TypeContext>.GetOrCreate(ImmutableArrayFactory.BuildWithUniqueMiddleElement(20, _missCounter++));
+            }
+            return result;
         }
     }
 }
 
 /*
-BenchmarkDotNet v0.15.1, Windows 11 (10.0.26200.8457)
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8457/25H2/2025Update/HudsonValley2)
 12th Gen Intel Core i7-12700H 2.30GHz, 1 CPU, 20 logical and 14 physical cores
 .NET SDK 10.0.300
-  [Host] : .NET 10.0.8 (10.0.826.23019), X64 RyuJIT AVX2
-  net10  : .NET 10.0.8 (10.0.826.23019), X64 RyuJIT AVX2
+  [Host] : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
+  net10  : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
   net481 : .NET Framework 4.8.1 (4.8.9325.0), X64 RyuJIT VectorSize=256
 
-| Method                                 | Job    | Mean         | Error         | StdDev      | Gen0   | Gen1   | Allocated |
-|--------------------------------------- |------- |-------------:|--------------:|------------:|-------:|-------:|----------:|
-| GetOrCreate_CacheHit_Long              | net10  |    92.454 ns |     1.8100 ns |   1.7777 ns |      - |      - |         - |
-| GetOrCreate_CacheHit_Long              | net481 |   189.911 ns |     3.2094 ns |   2.8450 ns |      - |      - |         - |
-| GetOrCreate_CacheHit_Short             | net10  |    30.901 ns |     0.4236 ns |   0.3962 ns |      - |      - |         - |
-| GetOrCreate_CacheHit_Short             | net481 |    64.527 ns |     1.0955 ns |   1.0248 ns |      - |      - |         - |
-| GetOrCreate_CacheMiss_Long             | net10  | 3,191.616 ns |   371.6088 ns | 329.4216 ns | 0.1488 | 0.0381 |    1888 B |
-| GetOrCreate_CacheMiss_Long             | net481 | 4,554.047 ns |   215.4445 ns | 190.9859 ns | 0.3967 | 0.0839 |    2519 B |
-| GetOrCreate_CacheMiss_Long_TailVaries  | net10  | 3,185.128 ns |   174.1148 ns | 154.3482 ns | 0.1488 | 0.0381 |    1888 B |
-| GetOrCreate_CacheMiss_Long_TailVaries  | net481 | 4,193.878 ns |   195.8028 ns | 173.5741 ns | 0.5035 | 0.1373 |    3452 B |
-| GetOrCreate_CacheMiss_Short            | net10  | 2,362.822 ns |   255.4965 ns | 226.4910 ns | 0.0420 | 0.0210 |     527 B |
-| GetOrCreate_CacheMiss_Short            | net481 | 3,178.519 ns | 1,010.2600 ns | 944.9979 ns | 0.1030 | 0.0267 |     650 B |
-| GetOrCreate_CacheMiss_Short_TailVaries | net10  | 2,342.099 ns |   305.2144 ns | 270.5646 ns | 0.0420 | 0.0210 |     528 B |
-| GetOrCreate_CacheMiss_Short_TailVaries | net481 | 3,298.285 ns |   386.7766 ns | 301.9697 ns | 0.1030 | 0.0324 |     658 B |
-| GetOrCreate_Empty                      | net10  |     4.594 ns |     0.1335 ns |   0.1428 ns |      - |      - |         - |
-| GetOrCreate_Empty                      | net481 |    12.106 ns |     0.1091 ns |   0.0967 ns |      - |      - |         - |
+InvocationCount=1  UnrollFactor=1
+
+| Method                              | Job    | Mean           | Error         | StdDev        | Median         | Gen0   | Gen1   | Gen2   | Allocated |
+|------------------------------------ |------- |---------------:|--------------:|--------------:|---------------:|-------:|-------:|-------:|----------:|
+| GetOrCreate_DictHit_Long            | net10  |     122.453 ns |     2.2861 ns |     4.2939 ns |     121.798 ns |      - |      - |      - |         - |
+| GetOrCreate_DictHit_Long            | net481 |     231.800 ns |     4.1890 ns |     3.9183 ns |     231.807 ns |      - |      - |      - |         - |
+| GetOrCreate_DictHit_Short           | net10  |      63.520 ns |     1.2611 ns |     2.7415 ns |      63.050 ns |      - |      - |      - |         - |
+| GetOrCreate_DictHit_Short           | net481 |     102.215 ns |     2.0068 ns |     2.2306 ns |     102.851 ns |      - |      - |      - |         - |
+| GetOrCreate_Empty                   | net10  |       3.977 ns |     0.0466 ns |     0.0436 ns |       3.977 ns |      - |      - |      - |         - |
+| GetOrCreate_Empty                   | net481 |      12.998 ns |     0.0794 ns |     0.0704 ns |      12.974 ns |      - |      - |      - |         - |
+| GetOrCreate_Miss_MiddleVaries_Long  | net10  |  64,299.202 ns | 1,456.5561 ns | 4,294.6888 ns |  63,710.525 ns |      - |      - |      - |    1776 B |
+| GetOrCreate_Miss_MiddleVaries_Long  | net481 | 122,452.693 ns | 1,883.7521 ns | 1,762.0629 ns | 121,959.350 ns |      - |      - |      - |    2396 B |
+| GetOrCreate_Miss_MiddleVaries_Short | net10  | 120,740.832 ns | 2,365.9418 ns | 2,992.1591 ns | 120,325.005 ns |      - |      - |      - |     466 B |
+| GetOrCreate_Miss_MiddleVaries_Short | net481 | 111,712.478 ns | 2,134.4820 ns | 2,283.8718 ns | 111,125.402 ns | 0.0500 |      - |      - |     526 B |
+| GetOrCreate_Miss_TailVaries_Long    | net10  |   1,783.799 ns |    35.2943 ns |    93.5955 ns |   1,770.565 ns | 0.1455 | 0.0364 |      - |    1993 B |
+| GetOrCreate_Miss_TailVaries_Long    | net481 |   3,254.096 ns |    64.0123 ns |   137.7932 ns |   3,195.556 ns | 0.4182 | 0.1091 | 0.0364 |    2613 B |
+| GetOrCreate_Miss_TailVaries_Short   | net10  |     892.240 ns |    17.0059 ns |    33.9626 ns |     883.653 ns | 0.0400 | 0.0200 |      - |     623 B |
+| GetOrCreate_Miss_TailVaries_Short   | net481 |   1,437.001 ns |    32.7436 ns |    96.0314 ns |   1,410.052 ns | 0.1100 | 0.0400 | 0.0200 |     704 B |
+| GetOrCreate_Miss_Unique_Long        | net10  |   1,779.124 ns |    34.7808 ns |    65.3267 ns |   1,762.583 ns | 0.1538 | 0.0462 |      - |    1974 B |
+| GetOrCreate_Miss_Unique_Long        | net481 |   3,085.658 ns |    58.6840 ns |    65.2271 ns |   3,071.978 ns | 0.4308 | 0.1077 | 0.0462 |    2604 B |
+| GetOrCreate_Miss_Unique_Short       | net10  |   1,291.066 ns |    25.5915 ns |    58.8006 ns |   1,290.112 ns | 0.0500 | 0.0250 | 0.0050 |     633 B |
+| GetOrCreate_Miss_Unique_Short       | net481 |   1,769.416 ns |    34.1502 ns |    45.5896 ns |   1,769.187 ns | 0.1150 | 0.0400 | 0.0150 |     711 B |
+| GetOrCreate_MruHit_Long             | net10  |      90.103 ns |     1.7478 ns |     2.2727 ns |      89.641 ns |      - |      - |      - |         - |
+| GetOrCreate_MruHit_Long             | net481 |     194.187 ns |     3.6635 ns |     3.5981 ns |     193.643 ns |      - |      - |      - |         - |
+| GetOrCreate_MruHit_Short            | net10  |      30.476 ns |     0.5442 ns |     0.5091 ns |      30.232 ns |      - |      - |      - |         - |
+| GetOrCreate_MruHit_Short            | net481 |      63.255 ns |     1.2377 ns |     2.0679 ns |      63.529 ns |      - |      - |      - |         - |
 
 // * Warnings *
 MultimodalDistribution
-  EquatableImmutableArrayInstanceCacheBenchmarks.GetOrCreate_CacheMiss_Long: net10  -> It seems that the distribution is bimodal (mValue = 3.25)
-  EquatableImmutableArrayInstanceCacheBenchmarks.GetOrCreate_CacheMiss_Short: net10 -> It seems that the distribution is bimodal (mValue = 3.33)
-
+  EquatableImmutableArrayInstanceCacheBenchmarks.GetOrCreate_Miss_TailVaries_Long: net10 -> It seems that the distribution is bimodal (mValue = 3.67)
+  EquatableImmutableArrayInstanceCacheBenchmarks.GetOrCreate_Miss_Unique_Short: net10    -> It seems that the distribution is bimodal (mValue = 3.37)
+MinIterationTime
+  EquatableImmutableArrayInstanceCacheBenchmarks.GetOrCreate_Empty: net10                 -> The minimum observed iteration time is 97.671ms which is very small. It's recommended to increase it to at least 100ms using more operations.
+  EquatableImmutableArrayInstanceCacheBenchmarks.GetOrCreate_Miss_TailVaries_Long: net10  -> The minimum observed iteration time is 90.708ms which is very small. It's recommended to increase it to at least 100ms using more operations.
+  EquatableImmutableArrayInstanceCacheBenchmarks.GetOrCreate_Miss_TailVaries_Short: net10 -> The minimum observed iteration time is 83.901ms which is very small. It's recommended to increase it to at least 100ms using more operations.
 
 */

--- a/benchmarks/IncrementalGeneratorExtensions.Benchmarks/ImmutableArrayFactory.cs
+++ b/benchmarks/IncrementalGeneratorExtensions.Benchmarks/ImmutableArrayFactory.cs
@@ -47,6 +47,28 @@ namespace Datacute.IncrementalGeneratorExtensions.Benchmarks
             return builder.MoveToImmutable();
         }
 
+        /// <summary>
+        /// Build an array where the middle element is unique (specified by <paramref name="middleElementId"/>),
+        /// all other elements follow a predictable sequence.
+        /// </summary>
+        public static ImmutableArray<TypeContext> BuildWithUniqueMiddleElement(int length, int middleElementId)
+        {
+            var builder = ImmutableArray.CreateBuilder<TypeContext>(length);
+            int middleIndex = length / 2; // for even lengths this chooses the upper-middle index
+            for (int i = 0; i < length; i++)
+            {
+                if (i == middleIndex)
+                {
+                    builder.Add(CreateTypeContext(middleElementId));
+                }
+                else
+                {
+                    builder.Add(CreateTypeContext(i));
+                }
+            }
+            return builder.MoveToImmutable();
+        }
+
         public static ImmutableArray<TypeContext> BuildShort(params int[] ids)
         {
             var builder = ImmutableArray.CreateBuilder<TypeContext>(ids.Length);

--- a/benchmarks/IncrementalGeneratorExtensions.Benchmarks/IndentingLineAppenderBenchmarks.cs
+++ b/benchmarks/IncrementalGeneratorExtensions.Benchmarks/IndentingLineAppenderBenchmarks.cs
@@ -263,21 +263,21 @@ BenchmarkDotNet v0.15.1, Windows 11 (10.0.26200.8457)
   net10  : .NET 10.0.8 (10.0.826.23019), X64 RyuJIT AVX2
   net481 : .NET Framework 4.8.1 (4.8.9325.0), X64 RyuJIT VectorSize=256
 
-| Method                              | Job    | Mean         | Error      | StdDev     | Median       | Gen0   | Gen1   | Allocated |
-|------------------------------------ |------- |-------------:|-----------:|-----------:|-------------:|-------:|-------:|----------:|
-| AppendLine_IndentLevel5             | net10  |     8.118 ns |  0.2058 ns |  0.3495 ns |     8.093 ns |      - |      - |         - |
-| AppendLine_IndentLevel5             | net481 |    35.879 ns |  0.7397 ns |  0.7915 ns |    36.065 ns |      - |      - |         - |
-| AppendLine_NoIndent                 | net10  |     4.314 ns |  0.1293 ns |  0.2013 ns |     4.318 ns |      - |      - |         - |
-| AppendLine_NoIndent                 | net481 |    32.476 ns |  0.6544 ns |  0.6121 ns |    32.625 ns |      - |      - |         - |
-| AppendLines_10Lines_IndentLevel2    | net10  |    82.297 ns |  1.0314 ns |  0.9648 ns |    82.103 ns |      - |      - |         - |
-| AppendLines_10Lines_IndentLevel2    | net481 |   343.339 ns |  6.0705 ns |  5.6784 ns |   342.145 ns |      - |      - |         - |
-| FlatFile_50Lines                    | net10  |   211.348 ns |  4.2216 ns |  7.7194 ns |   211.709 ns | 0.0961 |      - |    1208 B |
-| FlatFile_50Lines                    | net481 | 1,616.708 ns | 24.7631 ns | 23.1634 ns | 1,607.716 ns | 0.1907 |      - |    1212 B |
-| NestedBlocks_TabIndent_ThreeMethods | net10  |   323.470 ns |  6.7739 ns | 19.7599 ns |   316.250 ns | 0.4187 | 0.0062 |    5256 B |
-| NestedBlocks_TabIndent_ThreeMethods | net481 | 1,216.444 ns | 24.1718 ns | 39.7150 ns | 1,208.884 ns | 0.8507 | 0.0114 |    5360 B |
-| NestedBlocks_ThreeMethods           | net10  |   234.719 ns |  4.5601 ns | 10.3857 ns |   232.536 ns | 0.0987 |      - |    1240 B |
-| NestedBlocks_ThreeMethods           | net481 | 1,058.340 ns | 11.8516 ns | 11.0860 ns | 1,058.196 ns | 0.1984 |      - |    1252 B |
-| TypicalSourceFile                   | net10  |   317.834 ns |  6.3022 ns | 11.0379 ns |   313.914 ns | 0.1788 |      - |    2248 B |
-| TypicalSourceFile                   | net481 | 1,538.709 ns | 15.6182 ns | 14.6092 ns | 1,534.470 ns | 0.3586 |      - |    2263 B |
+| Method                              | Job    | Mean         | Error      | StdDev     | Gen0   | Gen1   | Allocated |
+|------------------------------------ |------- |-------------:|-----------:|-----------:|-------:|-------:|----------:|
+| AppendLine_IndentLevel5             | net10  |     6.967 ns |  0.1807 ns |  0.1856 ns |      - |      - |         - |
+| AppendLine_IndentLevel5             | net481 |    35.642 ns |  0.1936 ns |  0.1716 ns |      - |      - |         - |
+| AppendLine_NoIndent                 | net10  |     4.211 ns |  0.1243 ns |  0.1163 ns |      - |      - |         - |
+| AppendLine_NoIndent                 | net481 |    31.997 ns |  0.4872 ns |  0.4319 ns |      - |      - |         - |
+| AppendLines_10Lines_IndentLevel2    | net10  |    80.139 ns |  1.5635 ns |  1.5356 ns |      - |      - |         - |
+| AppendLines_10Lines_IndentLevel2    | net481 |   340.915 ns |  6.8392 ns |  8.1415 ns |      - |      - |         - |
+| FlatFile_50Lines                    | net10  |   184.883 ns |  3.0740 ns |  2.7251 ns | 0.0961 |      - |    1208 B |
+| FlatFile_50Lines                    | net481 | 1,531.134 ns | 23.2261 ns | 30.2005 ns | 0.1907 |      - |    1212 B |
+| NestedBlocks_TabIndent_ThreeMethods | net10  |   269.311 ns |  4.5710 ns |  5.6136 ns | 0.4187 | 0.0062 |    5256 B |
+| NestedBlocks_TabIndent_ThreeMethods | net481 | 1,116.606 ns |  9.7044 ns |  8.1036 ns | 0.8507 |      - |    5360 B |
+| NestedBlocks_ThreeMethods           | net10  |   200.530 ns |  3.9825 ns |  5.5829 ns | 0.0987 |      - |    1240 B |
+| NestedBlocks_ThreeMethods           | net481 | 1,007.518 ns | 18.6248 ns | 28.4420 ns | 0.1984 |      - |    1252 B |
+| TypicalSourceFile                   | net10  |   267.524 ns |  5.2597 ns |  6.6518 ns | 0.1788 |      - |    2248 B |
+| TypicalSourceFile                   | net481 | 1,506.055 ns | 17.4013 ns | 14.5308 ns | 0.3586 |      - |    2263 B |
 
 */

--- a/benchmarks/IncrementalGeneratorExtensions.Benchmarks/LightweightTraceBenchmarks.cs
+++ b/benchmarks/IncrementalGeneratorExtensions.Benchmarks/LightweightTraceBenchmarks.cs
@@ -101,20 +101,20 @@ BenchmarkDotNet v0.15.1, Windows 11 (10.0.26200.8457)
 
 | Method                      | Job    | Mean       | Error     | StdDev    | Median     | Allocated |
 |---------------------------- |------- |-----------:|----------:|----------:|-----------:|----------:|
-| Add_Composite               | net10  | 27.9431 ns | 0.4604 ns | 0.4081 ns | 27.8671 ns |         - |
-| Add_Composite               | net481 | 39.4892 ns | 0.7954 ns | 1.1151 ns | 38.9476 ns |         - |
-| Add_Simple                  | net10  | 27.7514 ns | 0.2972 ns | 0.2634 ns | 27.7237 ns |         - |
-| Add_Simple                  | net481 | 38.8105 ns | 0.3512 ns | 0.3113 ns | 38.7969 ns |         - |
-| DecodeKey                   | net10  |  0.0001 ns | 0.0004 ns | 0.0004 ns |  0.0000 ns |         - |
-| DecodeKey                   | net481 |  7.8579 ns | 0.0680 ns | 0.0603 ns |  7.8615 ns |         - |
-| EncodeKey                   | net10  |  0.0069 ns | 0.0080 ns | 0.0071 ns |  0.0057 ns |         - |
-| EncodeKey                   | net481 |  0.0164 ns | 0.0101 ns | 0.0094 ns |  0.0181 ns |         - |
-| IncrementCount_Composite    | net10  |  4.2033 ns | 0.0443 ns | 0.0370 ns |  4.2069 ns |         - |
-| IncrementCount_Composite    | net481 |  8.9732 ns | 0.1968 ns | 0.2343 ns |  9.0402 ns |         - |
-| IncrementCount_EnumOverload | net10  |  4.3778 ns | 0.1078 ns | 0.1283 ns |  4.3421 ns |         - |
-| IncrementCount_EnumOverload | net481 |  8.1454 ns | 0.1772 ns | 0.2177 ns |  8.1805 ns |         - |
-| IncrementCount_Simple       | net10  |  4.2445 ns | 0.0648 ns | 0.0574 ns |  4.2432 ns |         - |
-| IncrementCount_Simple       | net481 |  8.2045 ns | 0.1839 ns | 0.2044 ns |  8.1801 ns |         - |
+| Add_Composite               | net10  | 27.5475 ns | 0.2628 ns | 0.2330 ns | 27.5307 ns |         - |
+| Add_Composite               | net481 | 38.5967 ns | 0.2179 ns | 0.2141 ns | 38.5779 ns |         - |
+| Add_Simple                  | net10  | 27.3032 ns | 0.2102 ns | 0.1641 ns | 27.2731 ns |         - |
+| Add_Simple                  | net481 | 38.3498 ns | 0.4221 ns | 0.3742 ns | 38.2586 ns |         - |
+| DecodeKey                   | net10  |  0.0011 ns | 0.0032 ns | 0.0028 ns |  0.0000 ns |         - |
+| DecodeKey                   | net481 |  7.6176 ns | 0.0723 ns | 0.0676 ns |  7.5977 ns |         - |
+| EncodeKey                   | net10  |  0.0000 ns | 0.0000 ns | 0.0000 ns |  0.0000 ns |         - |
+| EncodeKey                   | net481 |  0.0055 ns | 0.0098 ns | 0.0096 ns |  0.0001 ns |         - |
+| IncrementCount_Composite    | net10  |  4.2282 ns | 0.0537 ns | 0.0419 ns |  4.2191 ns |         - |
+| IncrementCount_Composite    | net481 |  9.2481 ns | 0.2052 ns | 0.2281 ns |  9.1806 ns |         - |
+| IncrementCount_EnumOverload | net10  |  4.1845 ns | 0.0383 ns | 0.0340 ns |  4.1844 ns |         - |
+| IncrementCount_EnumOverload | net481 |  7.6360 ns | 0.1747 ns | 0.1794 ns |  7.6799 ns |         - |
+| IncrementCount_Simple       | net10  |  4.2527 ns | 0.1049 ns | 0.1248 ns |  4.2063 ns |         - |
+| IncrementCount_Simple       | net481 |  7.8308 ns | 0.1236 ns | 0.1032 ns |  7.8495 ns |         - |
 
 // * Warnings *
 ZeroMeasurement

--- a/docs/EquatableImmutableArray README.md
+++ b/docs/EquatableImmutableArray README.md
@@ -84,7 +84,7 @@ With LightweightTrace + GeneratorStage included you may see counters:
 * `EquatableImmutableArrayCacheHit` – structural reuse (fast path success).
 * `EquatableImmutableArrayCacheMiss` – new distinct sequence added to cache.
 * `EquatableImmutableArrayCacheWeakReferenceRemoved` – stale wrapper slot cleaned.
-* `EquatableImmutableArrayLength` – length histogram to spot pathological sizes.
+* `EquatableImmutableArrayInstanceCacheSize` – tracks the number of cached items per mapped type.
 Disable by excluding `LightweightTrace` or `GeneratorStage`, or by disabling the cache (miss counters suppressed in non‑cache mode).
 
 ### Memory Considerations

--- a/docs/LightweightTrace README.md
+++ b/docs/LightweightTrace README.md
@@ -78,8 +78,8 @@ Trace Log:
 LightweightTrace.IncrementCount(GeneratorStage.ForAttributeWithMetadataNamePredicate);
 LightweightTrace.Add(GeneratorStage.ForAttributeWithMetadataNamePipelineOutput);
 
-// EquatableImmutableArray Length histogram bucket
-LightweightTrace.IncrementCount(GeneratorStage.EquatableImmutableArrayLength, values.Length);
+// EquatableImmutableArray instance cache size histogram bucket
+LightweightTrace.IncrementCount(GeneratorStage.EquatableImmutableArrayInstanceCacheSize, typeMapId, true);
 
 // Method call mapping (shows up as Method Call (...))
 LightweightTrace.Add(GeneratorStage.RegisterSourceOutput);

--- a/docs/LightweightTrace README.md
+++ b/docs/LightweightTrace README.md
@@ -3,7 +3,7 @@
 ---
 # LightweightTrace.cs and LightweightTraceExtensions.cs
 LightweightTrace is a zero‑allocation instrumentation layer for incremental source generators: a timestamped ring buffer of events plus composite-key counters (id + optional value + mapping flag) that represent histograms, categorical buckets, and method-call frequencies.
-It can emit a single embedded diagnostics comment (counters + trace) into generated source so you can understand pipeline behavior (frequency, timing patterns, entry/exit flow) without external tooling. LightweightTraceExtensions wires this into IncrementalValue/Values providers and adds cancellation logging helpers.
+It can emit a single embedded diagnostics comment (counters + trace) into generated source so you can understand pipeline behaviour (frequency, timing patterns, entry/exit flow) without external tooling. LightweightTraceExtensions wires this into IncrementalValue/Values providers and adds cancellation logging helpers.
 ## Sample Diagnostics Output
 ```text
 /* Diagnostics
@@ -78,7 +78,7 @@ Trace Log:
 LightweightTrace.IncrementCount(GeneratorStage.ForAttributeWithMetadataNamePredicate);
 LightweightTrace.Add(GeneratorStage.ForAttributeWithMetadataNamePipelineOutput);
 
-// EquatableImmutableArray instance cache size histogram bucket
+// Instance cache size metrics for a generic type
 LightweightTrace.IncrementCount(GeneratorStage.EquatableImmutableArrayInstanceCacheSize, typeMapId, true);
 
 // Method call mapping (shows up as Method Call (...))
@@ -104,7 +104,7 @@ When diagnostics text is rendered, name lookup uses this precedence:
 2. The shared custom map set once with `LightweightTrace.SetCustomEventNames(...)`.
 3. Runtime registrations created via `LightweightTrace.RegisterName(...)`.
 
-This allows a mixed model where stable pipeline/event names are supplied up front, while runtime-discovered mapped values (for example, generic type names used by cache metrics) are registered dynamically.
+This allows a mixed model where stable pipeline/event names are supplied up front, while runtime-discovered names, such as generic type names used by instance-cache metrics, are registered dynamically.
 
 Example setup:
 ```csharp

--- a/docs/LightweightTrace README.md
+++ b/docs/LightweightTrace README.md
@@ -94,14 +94,30 @@ LightweightTrace.MethodExit(GeneratorStage.Initialize);
 - Counters (simple, histogram buckets, mapped enum categories).
 - Time-stamped rolling trace (ring buffer) with method entry/exit tagging.
 - Automatic method call counting (except MethodExit) for frequency insight.
-- Name mapping for ids and (optionally flagged) values via built-in GeneratorStage / GeneratorStageDescriptions plus your own merged enum map.
+- Name mapping for ids and mapped values from three sources: per-call map, shared custom map, and runtime-registered names.
 - AppendDiagnosticsComment combines counters + trace into one embeddable block.
 - Cancellation helpers record where cancellation was observed.
+
+## Name Mapping Sources
+When diagnostics text is rendered, name lookup uses this precedence:
+1. The map passed into `AppendCounts`, `AppendTrace`, or `AppendDiagnosticsComment`.
+2. The shared custom map set once with `LightweightTrace.SetCustomEventNames(...)`.
+3. Runtime registrations created via `LightweightTrace.RegisterName(...)`.
+
+This allows a mixed model where stable pipeline/event names are supplied up front, while runtime-discovered mapped values (for example, generic type names used by cache metrics) are registered dynamically.
+
+Example setup:
+```csharp
+LightweightTrace.SetCustomEventNames(GeneratorStageDescriptions.GeneratorStageNameMap);
+
+var typeMapId = LightweightTrace.RegisterName(typeof(MyType).ToString());
+LightweightTrace.IncrementCount(GeneratorStage.EquatableImmutableArrayInstanceCacheSize, typeMapId, mapValue: true);
+```
 ## Encoding (Brief)
 Composite key: composite = id + (value * CompositeValueShift) + (mapped ? MapValueFlag : 0). Decode splits into id, value, mapped flag. This keeps storage dense and lookups cheap.
 
 ## Extending GeneratorStage With Your Own Events
-You get a built-in baseline enum (GeneratorStage) and a name map (GeneratorStageDescriptions.GeneratorStageNameMap). Extend by defining your own enum with distinct numeric values (gaps are fine) and merge its names into a lazy dictionary so both built-in and custom events share one lookup.
+You get a built-in baseline enum (`GeneratorStage`) and a name map (`GeneratorStageDescriptions.GeneratorStageNameMap`). Extend by defining your own enum with distinct numeric values (gaps are fine) and merge its names into a dictionary so both built-in and custom events share one lookup.
 
 Example enum (abbreviated, made-up stages):
 ```csharp
@@ -146,7 +162,7 @@ LightweightTrace.IncrementCount(GeneratorStage.MethodCall,
     (int)MyPipelineStage.OutputComposed, mapValue: true);                      // categorical mapping
 buffer.AppendDiagnosticsComment(MyPipelineStageDescriptions.EventNameMap);    // merged names
 ```
-Result: diagnostics output shows both core GeneratorStage events and your custom stages with readable names.
+Result: diagnostics output shows both core `GeneratorStage` events and your custom stages with readable names.
 
 ## Recommended Numeric ID Ranges
 CompositeValueShift = 1024, so valid base event/counter IDs (the id portion) are 0–1023.


### PR DESCRIPTION
## Summary
This PR refines the lightweight tracing support for instance cache metrics and runtime name lookup. It keeps cache size tracking tied to generic types while allowing diagnostics to render names discovered at runtime.

## What changed
- Instance cache size metrics are tracked per generic type.
- LightweightTrace now supports runtime-discovered names such as generic type names.
- Documentation and changelog entries were updated to match the behaviour.

## Why
- Makes instance cache diagnostics more readable and consistent.
- Preserves stable pipeline names while supporting dynamic cache labels.

## Validation
- Git status is clean.
- Branch is up to date with its remote tracking branch.

## Notes
- None.

## Checks
- [x] Changelog updated
- [x] Working tree clean
- [x] Branch pushed
- [x] Target branch confirmed
- [x] CI passed