### PR TITLE
Add optional EventSource mode to LightweightTrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optional `LightweightTrace` EventSource mode behind `DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE` for cross-platform diagnostic event streaming (ETW on Windows and EventPipe-compatible tooling on Linux/macOS).
+
 ### Changed
 
 - Instance cache size metrics are now tracked per generic type.

--- a/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/LightweightTrace.cs
+++ b/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/LightweightTrace.cs
@@ -1,8 +1,9 @@
-﻿#if !DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE
+#if !DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -47,6 +48,8 @@ namespace Datacute.IncrementalGeneratorExtensions
         private static readonly (long, int)[] Events = new (long, int)[Capacity];
         private static int _index;
 
+        private static LightweightTraceEventSource _etwLog;
+        private static EventLevel _etwLevel = EventLevel.Informational;
         /// <summary>
         /// Custom names supplied by the caller for event IDs and mapped values.
         /// </summary>
@@ -106,12 +109,114 @@ namespace Datacute.IncrementalGeneratorExtensions
         }
 
         /// <summary>
+        /// Initializes ETW logging with a custom event source name and event level.
+        /// </summary>
+        /// <param name="eventSourceName">The name of the ETW event source.</param>
+        /// <param name="eventLevel">The event level for the traces.</param>
+        /// <param name="eventNameMap">A dictionary mapping event IDs and values to their names, used to turn raw numeric event IDs and values into meaningful ETW output.</param>
+        public static void InitializeEtw(string eventSourceName = "Datacute-IncrementalGenerator-Trace", EventLevel eventLevel = EventLevel.Informational, Dictionary<int, string> eventNameMap = null)
+        {
+            if (_etwLog == null || _etwLog.Name != eventSourceName)
+            {
+                try
+                {
+                    _etwLog?.Dispose();
+                    _etwLog = new LightweightTraceEventSource(eventSourceName);
+                }
+                catch (ArgumentException)
+                {
+                    _etwLog = null;
+                }
+            }
+
+            _etwLevel = eventLevel;
+            if (eventNameMap != null)
+            {
+                SetCustomEventNames(eventNameMap);
+            }
+        }
+
+        private sealed class LightweightTraceEventSource : EventSource
+        {
+            public LightweightTraceEventSource(string eventSourceName) : base(eventSourceName)
+            {
+            }
+
+            [Event(1, Level = EventLevel.Critical)]
+            private void TraceCritical(int id, int value, bool isMappedValue, string message) => WriteEvent(1, id, value, isMappedValue, message);
+
+            [Event(2, Level = EventLevel.Error)]
+            private void TraceError(int id, int value, bool isMappedValue, string message) => WriteEvent(2, id, value, isMappedValue, message);
+
+            [Event(3, Level = EventLevel.Warning)]
+            private void TraceWarning(int id, int value, bool isMappedValue, string message) => WriteEvent(3, id, value, isMappedValue, message);
+
+            [Event(4, Level = EventLevel.Informational)]
+            private void TraceInformational(int id, int value, bool isMappedValue, string message) => WriteEvent(4, id, value, isMappedValue, message);
+
+            [Event(5, Level = EventLevel.Verbose)]
+            private void TraceVerbose(int id, int value, bool isMappedValue, string message) => WriteEvent(5, id, value, isMappedValue, message);
+
+            [Event(6, Level = EventLevel.Critical)]
+            private void CountCritical(int id, int value, bool isMappedValue, long count, string message) => WriteEvent(6, id, value, isMappedValue, count, message);
+
+            [Event(7, Level = EventLevel.Error)]
+            private void CountError(int id, int value, bool isMappedValue, long count, string message) => WriteEvent(7, id, value, isMappedValue, count, message);
+
+            [Event(8, Level = EventLevel.Warning)]
+            private void CountWarning(int id, int value, bool isMappedValue, long count, string message) => WriteEvent(8, id, value, isMappedValue, count, message);
+
+            [Event(9, Level = EventLevel.Informational)]
+            private void CountInformational(int id, int value, bool isMappedValue, long count, string message) => WriteEvent(9, id, value, isMappedValue, count, message);
+
+            [Event(10, Level = EventLevel.Verbose)]
+            private void CountVerbose(int id, int value, bool isMappedValue, long count, string message) => WriteEvent(10, id, value, isMappedValue, count, message);
+
+            [NonEvent]
+            public void Trace(EventLevel level, int id, int value, bool isMappedValue, string message)
+            {
+                if (IsEnabled(level, EventKeywords.None))
+                {
+                    switch (level)
+                    {
+                        case EventLevel.Critical: TraceCritical(id, value, isMappedValue, message); break;
+                        case EventLevel.Error: TraceError(id, value, isMappedValue, message); break;
+                        case EventLevel.Warning: TraceWarning(id, value, isMappedValue, message); break;
+                        case EventLevel.Informational: TraceInformational(id, value, isMappedValue, message); break;
+                        case EventLevel.Verbose: TraceVerbose(id, value, isMappedValue, message); break;
+                        default: TraceInformational(id, value, isMappedValue, message); break;
+                    }
+                }
+            }
+
+            [NonEvent]
+            public void Count(EventLevel level, int id, int value, bool isMappedValue, long count, string message)
+            {
+                if (IsEnabled(level, EventKeywords.None))
+                {
+                    switch (level)
+                    {
+                        case EventLevel.Critical: CountCritical(id, value, isMappedValue, count, message); break;
+                        case EventLevel.Error: CountError(id, value, isMappedValue, count, message); break;
+                        case EventLevel.Warning: CountWarning(id, value, isMappedValue, count, message); break;
+                        case EventLevel.Informational: CountInformational(id, value, isMappedValue, count, message); break;
+                        case EventLevel.Verbose: CountVerbose(id, value, isMappedValue, count, message); break;
+                        default: CountInformational(id, value, isMappedValue, count, message); break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Adds an event to the trace log with the specified event ID.
         /// </summary>
         /// <param name="eventId">The ID of the event to log.</param>
         /// <typeparam name="TEnum">The type of the event ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
         public static void Add<TEnum>(TEnum eventId) where TEnum : Enum
-            => Add(System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref eventId));
+            => AddInternal(
+                eventId: System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref eventId), 
+                value: 0, 
+                mapValue: false);
 
         /// <summary>
         /// Adds an event to the trace log with the specified event ID and numeric value.
@@ -120,7 +225,10 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// <param name="value">The value associated with the event, which can be used for additional context or categorisation.</param>
         /// <typeparam name="TEnum">The type of the event ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
         public static void Add<TEnum>(TEnum eventId, int value) where TEnum : Enum
-            => Add(System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref eventId), value);
+            => AddInternal(
+                eventId: System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref eventId), 
+                value: value, 
+                mapValue: false);
 
         /// <summary>
         /// Adds an event to the trace log with the specified event ID and enum value.
@@ -132,7 +240,10 @@ namespace Datacute.IncrementalGeneratorExtensions
         public static void Add<TEnumKey, TEnumValue>(TEnumKey eventId, TEnumValue value)
             where TEnumKey : Enum
             where TEnumValue : Enum
-            => Add(System.Runtime.CompilerServices.Unsafe.As<TEnumKey, int>(ref eventId), System.Runtime.CompilerServices.Unsafe.As<TEnumValue, int>(ref value), true);
+            => AddInternal(
+                eventId: System.Runtime.CompilerServices.Unsafe.As<TEnumKey, int>(ref eventId), 
+                value: System.Runtime.CompilerServices.Unsafe.As<TEnumValue, int>(ref value), 
+                mapValue: true);
 
         /// <summary>
         /// Adds an event to the trace log with the specified numeric event ID and value.
@@ -140,7 +251,8 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// <param name="eventId">The ID of the event to log.</param>
         /// <param name="value">The value associated with the event, which can be used for additional context or categorisation.</param>
         /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
-        public static void Add(int eventId, int value, bool mapValue = false) => Add(EncodeKey(eventId, value, mapValue));
+        public static void Add(int eventId, int value, bool mapValue = false)
+            => AddInternal(eventId, value, mapValue);
 
         /// <summary>
         /// Adds an event to the trace log with the specified numeric event ID.
@@ -148,18 +260,7 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// <param name="eventId">The ID of the event to log.</param>
         /// <param name="mapValue">If true, and the eventId encapsulates a value, the value is treated as a mapped value when generating the diagnostic log.</param>
         public static void Add(int eventId, bool mapValue = false)
-        {
-            var index = Interlocked.Increment(ref _index) % Capacity;
-            Events[index] = (Stopwatch.ElapsedTicks, eventId | (mapValue ? MapValueFlag : 0));
-#if !DATACUTE_EXCLUDE_GENERATORSTAGE
-            if ((eventId / CompositeValueShift) != (int)GeneratorStage.MethodExit)
-            {
-                IncrementCount((int)GeneratorStage.MethodCall, eventId % CompositeValueShift, true);
-            }
-#else
-            IncrementCount(eventId % CompositeValueShift);
-#endif
-        }
+            => AddInternal(eventId, 0, mapValue);
 
 #if !DATACUTE_EXCLUDE_GENERATORSTAGE
         /// <summary>
@@ -167,14 +268,22 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// </summary>
         /// <param name="eventId">The ID of the event to log.</param>
         /// <typeparam name="TEnum">The type of the event ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
-        public static void MethodEntry<TEnum>(TEnum eventId) where TEnum : Enum => Add(System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref eventId), (int)GeneratorStage.MethodEntry, true);
+        public static void MethodEntry<TEnum>(TEnum eventId) where TEnum : Enum
+            => AddInternal(
+                eventId: System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref eventId), 
+                value: (int)GeneratorStage.MethodEntry, 
+                mapValue: true);
 
         /// <summary>
         /// Adds a method exit event to the trace log with the specified event ID.
         /// </summary>
         /// <param name="eventId">The ID of the event to log.</param>
         /// <typeparam name="TEnum">The type of the event ID, which must be an enum, either <see cref="GeneratorStage"/>, or your own.</typeparam>
-        public static void MethodExit<TEnum>(TEnum eventId) where TEnum : Enum => Add(System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref eventId), (int)GeneratorStage.MethodExit, true);
+        public static void MethodExit<TEnum>(TEnum eventId) where TEnum : Enum
+            => AddInternal(
+                eventId: System.Runtime.CompilerServices.Unsafe.As<TEnum, int>(ref eventId), 
+                value: (int)GeneratorStage.MethodExit, 
+                mapValue: true);
 #endif
 
         /// <summary>
@@ -300,7 +409,14 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// <param name="counterId">The ID of the counter to increment.</param>
         /// <param name="value">The value associated with the counter, which can be used for additional context or categorisation.</param>
         /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
-        public static void IncrementCount(int counterId, int value, bool mapValue = false) => Interlocked.Increment(ref GetOrAddCounter(EncodeKey(counterId, value, mapValue)).Value);
+        public static void IncrementCount(int counterId, int value, bool mapValue = false)
+        {
+            var key = EncodeKey(counterId, value, mapValue);
+            var index = Interlocked.Increment(ref _index) % Capacity;
+            Events[index] = (Stopwatch.ElapsedTicks, key);
+            TraceEtwCount(counterId, value, mapValue, 1L);
+            Interlocked.Increment(ref GetOrAddCounter(key).Value);
+        }
 
         /// <summary>
         /// Decrements the value of a given key by 1.
@@ -314,7 +430,14 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// <param name="counterId">The ID of the counter to decrement.</param>
         /// <param name="value">The value associated with the counter, which can be used for additional context or categorisation.</param>
         /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
-        public static void DecrementCount(int counterId, int value, bool mapValue = false) => Interlocked.Decrement(ref GetOrAddCounter(EncodeKey(counterId, value, mapValue)).Value);
+        public static void DecrementCount(int counterId, int value, bool mapValue = false)
+        {
+            var key = EncodeKey(counterId, value, mapValue);
+            var index = Interlocked.Increment(ref _index) % Capacity;
+            Events[index] = (Stopwatch.ElapsedTicks, key);
+            TraceEtwCount(counterId, value, mapValue, -1L);
+            Interlocked.Decrement(ref GetOrAddCounter(key).Value);
+        }
 
         /// <summary>
         /// Sets the value of a given key.
@@ -330,7 +453,14 @@ namespace Datacute.IncrementalGeneratorExtensions
         /// <param name="value">The value associated with the counter.</param>
         /// <param name="mapValue">If true, the value is treated as a mapped value when generating the diagnostic log.</param>
         /// <param name="count">The new value for the counter.</param>
-        public static void SetCount(int counterId, int value, bool mapValue, long count) => Interlocked.Exchange(ref GetOrAddCounter(EncodeKey(counterId, value, mapValue)).Value, count);
+        public static void SetCount(int counterId, int value, bool mapValue, long count)
+        {
+            var key = EncodeKey(counterId, value, mapValue);
+            var index = Interlocked.Increment(ref _index) % Capacity;
+            Events[index] = (Stopwatch.ElapsedTicks, key);
+            TraceEtwCount(counterId, value, mapValue, count);
+            Interlocked.Exchange(ref GetOrAddCounter(key).Value, count);
+        }
         
         /// <summary>
         /// Gets a string with the current cache performance metrics.
@@ -383,10 +513,46 @@ namespace Datacute.IncrementalGeneratorExtensions
             value = (key & ValueMask) >> ValueShift;
         }
 
+        private static void AddInternal(int eventId, int value, bool mapValue)
+        {
+            var key = EncodeKey(eventId, value, mapValue);
+            var index = Interlocked.Increment(ref _index) % Capacity;
+            Events[index] = (Stopwatch.ElapsedTicks, key);
+            TraceEtw(eventId, value, mapValue);
+            AddInternal(key);
+        }
+
+        private static void AddInternal(int key)
+        {
+            Interlocked.Increment(ref GetOrAddCounter(key).Value);
+        }
+
+        private static void TraceEtw(int eventId, int value, bool mapValue)
+        {
+            if (_etwLog != null && _etwLog.IsEnabled())
+            {
+                var message = FormatEventKey(eventId, value, mapValue);
+                _etwLog.Trace(_etwLevel, eventId, value, mapValue, message);
+            }
+        }
+
+        private static void TraceEtwCount(int counterId, int value, bool mapValue, long count)
+        {
+            if (_etwLog != null && _etwLog.IsEnabled())
+            {
+                var message = FormatEventKey(counterId, value, mapValue);
+                _etwLog.Count(_etwLevel, counterId, value, mapValue, count, message);
+            }
+        }
+
         private static string FormatEventKey(Dictionary<int, string> eventNameMap, int key)
         {
             DecodeKey(key, out var id, out var value, out var mapped);
+            return FormatEventKey(id, value, mapped, eventNameMap);
+        }
 
+        private static string FormatEventKey(int id, int value, bool mapped, Dictionary<int, string> eventNameMap = null)
+        {
             string idText = GetMappedName(eventNameMap, id);
             if (idText == null)
             {

--- a/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/LightweightTrace.cs
+++ b/IncrementalGeneratorExtensions.Content/Datacute/IncrementalGeneratorExtensions/LightweightTrace.cs
@@ -1,9 +1,11 @@
-#if !DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE
+﻿#if !DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+#if DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE
 using System.Diagnostics.Tracing;
+#endif
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -48,8 +50,10 @@ namespace Datacute.IncrementalGeneratorExtensions
         private static readonly (long, int)[] Events = new (long, int)[Capacity];
         private static int _index;
 
+#if DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE
         private static LightweightTraceEventSource _etwLog;
         private static EventLevel _etwLevel = EventLevel.Informational;
+#endif
         /// <summary>
         /// Custom names supplied by the caller for event IDs and mapped values.
         /// </summary>
@@ -108,6 +112,7 @@ namespace Datacute.IncrementalGeneratorExtensions
             return id;
         }
 
+#if DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE
         /// <summary>
         /// Initializes ETW logging with a custom event source name and event level.
         /// </summary>
@@ -206,6 +211,7 @@ namespace Datacute.IncrementalGeneratorExtensions
                 }
             }
         }
+#endif
 
         /// <summary>
         /// Adds an event to the trace log with the specified event ID.
@@ -414,7 +420,9 @@ namespace Datacute.IncrementalGeneratorExtensions
             var key = EncodeKey(counterId, value, mapValue);
             var index = Interlocked.Increment(ref _index) % Capacity;
             Events[index] = (Stopwatch.ElapsedTicks, key);
+#if DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE
             TraceEtwCount(counterId, value, mapValue, 1L);
+#endif
             Interlocked.Increment(ref GetOrAddCounter(key).Value);
         }
 
@@ -435,7 +443,9 @@ namespace Datacute.IncrementalGeneratorExtensions
             var key = EncodeKey(counterId, value, mapValue);
             var index = Interlocked.Increment(ref _index) % Capacity;
             Events[index] = (Stopwatch.ElapsedTicks, key);
+#if DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE
             TraceEtwCount(counterId, value, mapValue, -1L);
+#endif
             Interlocked.Decrement(ref GetOrAddCounter(key).Value);
         }
 
@@ -458,7 +468,9 @@ namespace Datacute.IncrementalGeneratorExtensions
             var key = EncodeKey(counterId, value, mapValue);
             var index = Interlocked.Increment(ref _index) % Capacity;
             Events[index] = (Stopwatch.ElapsedTicks, key);
+#if DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE
             TraceEtwCount(counterId, value, mapValue, count);
+#endif
             Interlocked.Exchange(ref GetOrAddCounter(key).Value, count);
         }
         
@@ -518,7 +530,9 @@ namespace Datacute.IncrementalGeneratorExtensions
             var key = EncodeKey(eventId, value, mapValue);
             var index = Interlocked.Increment(ref _index) % Capacity;
             Events[index] = (Stopwatch.ElapsedTicks, key);
+#if DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE
             TraceEtw(eventId, value, mapValue);
+#endif
             AddInternal(key);
         }
 
@@ -527,6 +541,7 @@ namespace Datacute.IncrementalGeneratorExtensions
             Interlocked.Increment(ref GetOrAddCounter(key).Value);
         }
 
+#if DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE
         private static void TraceEtw(int eventId, int value, bool mapValue)
         {
             if (_etwLog != null && _etwLog.IsEnabled())
@@ -544,6 +559,7 @@ namespace Datacute.IncrementalGeneratorExtensions
                 _etwLog.Count(_etwLevel, counterId, value, mapValue, count, message);
             }
         }
+#endif
 
         private static string FormatEventKey(Dictionary<int, string> eventNameMap, int key)
         {

--- a/docs/LightweightTrace README.md
+++ b/docs/LightweightTrace README.md
@@ -2,8 +2,12 @@
 
 ---
 # LightweightTrace.cs and LightweightTraceExtensions.cs
-LightweightTrace is a zero‑allocation instrumentation layer for incremental source generators: a timestamped ring buffer of events plus composite-key counters (id + optional value + mapping flag) that represent histograms, categorical buckets, and method-call frequencies.
-It can emit a single embedded diagnostics comment (counters + trace) into generated source so you can understand pipeline behaviour (frequency, timing patterns, entry/exit flow) without external tooling. LightweightTraceExtensions wires this into IncrementalValue/Values providers and adds cancellation logging helpers.
+LightweightTrace is a zero‑allocation instrumentation layer for incremental source generators supporting two complementary modes:
+
+- **Standard mode** (default): Ring-buffer timestamped events + composite-key counters for embedded diagnostics
+- **EventSource mode** (cross-platform): Direct integration with .NET diagnostic events (ETW on Windows; diagnostic tools on Linux/macOS)
+
+Both modes share the same public API and output formats. You get a timestamped event trace, composite-key counters (id + optional value + mapping flag) for histograms and categorical buckets, automatic method-call frequency counting, and unified AppendDiagnosticsComment output embeddable in generated code. EventSource mode optionally streams events to real-time diagnostic listeners. LightweightTraceExtensions wires this into IncrementalValue/Values providers and adds cancellation logging helpers.
 ## Sample Diagnostics Output
 ```text
 /* Diagnostics
@@ -203,6 +207,59 @@ The files will still appear in the project, but will not add anything to the com
 ### Note: Dependency
 `LightweightTraceExtensions.cs` depends on `LightweightTrace.cs` and will **not work** when it
 is excluded. (Unless you supply your own implementation of `LightweightTrace`.)
+
+## EventSource Mode (Cross-Platform Diagnostic Events)
+
+By default, LightweightTrace uses a ring-buffer implementation. You can optionally enable EventSource-based diagnostic event tracing by defining `DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE`:
+
+```XML
+<PropertyGroup>
+  <DefineConstants>$(DefineConstants);DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE</DefineConstants>
+</PropertyGroup>
+```
+
+### Benefits
+- **Integrates with platform diagnostic systems**: ETW on Windows, diagnostic listeners on Linux/macOS
+- **Lower latency**: Events are streamed to listeners in real time (when listeners are active)
+- **Same API**: Both modes share identical public methods; swap modes without code changes
+- **No divergence**: Single implementation prevents drift between modes
+- **Zero overhead when disabled**: No encode/decode cycles when EventSource is inactive
+
+### Usage
+When using EventSource mode, initialize tracing once at startup before any trace calls:
+
+```csharp
+// Initialize once at startup
+LightweightTrace.InitializeEtw(
+    eventSourceName: "MyGenerator-Trace",
+    eventLevel: EventLevel.Informational,
+    eventNameMap: MyGeneratorStageDescriptions.EventNameMap
+);
+
+// Use normally; events flow to both ring-buffer and active listeners
+LightweightTrace.Add(GeneratorStage.Processing);
+LightweightTrace.IncrementCount(GeneratorStage.ItemsProcessed, itemCount);
+```
+
+### Event Levels
+When using EventSource mode, you can control verbosity per event type:
+
+- **Critical**: Fatal errors requiring immediate attention
+- **Error**: Error conditions that may affect functionality
+- **Warning**: Potentially problematic conditions
+- **Informational** (default): General informational messages
+- **Verbose**: Detailed tracing for deep investigation
+
+Example: enable only warnings and above:
+```csharp
+LightweightTrace.InitializeEtw(eventLevel: EventLevel.Warning);
+```
+
+### Embedding Diagnostics vs. Real-Time Events
+- **Standard mode**: All tracing goes into the ring-buffer; call `AppendDiagnosticsComment()` to embed in generated source
+- **EventSource mode**: Events flow to both the ring-buffer (for embedding) and active diagnostic listeners simultaneously
+
+This means EventSource mode is ideal for **live profiling during development** while keeping the option to embed diagnostics for investigation in running code. When no listeners are active, EventSource calls are gated by `IsEnabled()` checks, minimizing overhead.
 
 ---
 <small>

--- a/docs/LightweightTrace README.md
+++ b/docs/LightweightTrace README.md
@@ -190,24 +190,6 @@ Guidelines:
 5. When mapping enum values (mapValue: true) ensure those enum members also have numeric values < CompositeValueShift so they fit the id naming space of the map.
 6. Avoid redefining an existing numeric ID with a new meaning once shipped; allocate a new ID instead.
  
-# Excluding the source files
-
-To disable the inclusion of a specific source file,
-define the relevant constant in the consuming project's `.csproj` file:
-
-```XML
-<PropertyGroup>
-  <DefineConstants>$(DefineConstants);DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE</DefineConstants>
-  <DefineConstants>$(DefineConstants);DATACUTE_EXCLUDE_LIGHTWEIGHTTRACEEXTENSIONS</DefineConstants>
-</PropertyGroup>
-```
-
-The files will still appear in the project, but will not add anything to the compilation.
-
-### Note: Dependency
-`LightweightTraceExtensions.cs` depends on `LightweightTrace.cs` and will **not work** when it
-is excluded. (Unless you supply your own implementation of `LightweightTrace`.)
-
 ## EventSource Mode (Cross-Platform Diagnostic Events)
 
 By default, LightweightTrace uses a ring-buffer implementation. You can optionally enable EventSource-based diagnostic event tracing by defining `DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE`:
@@ -260,6 +242,24 @@ LightweightTrace.InitializeEtw(eventLevel: EventLevel.Warning);
 - **EventSource mode**: Events flow to both the ring-buffer (for embedding) and active diagnostic listeners simultaneously
 
 This means EventSource mode is ideal for **live profiling during development** while keeping the option to embed diagnostics for investigation in running code. When no listeners are active, EventSource calls are gated by `IsEnabled()` checks, minimizing overhead.
+
+# Excluding the source files
+
+To disable the inclusion of a specific source file,
+define the relevant constant in the consuming project's `.csproj` file:
+
+```XML
+<PropertyGroup>
+  <DefineConstants>$(DefineConstants);DATACUTE_EXCLUDE_LIGHTWEIGHTTRACE</DefineConstants>
+  <DefineConstants>$(DefineConstants);DATACUTE_EXCLUDE_LIGHTWEIGHTTRACEEXTENSIONS</DefineConstants>
+</PropertyGroup>
+```
+
+The files will still appear in the project, but will not add anything to the compilation.
+
+### Note: Dependency
+`LightweightTraceExtensions.cs` depends on `LightweightTrace.cs` and will **not work** when it
+is excluded. (Unless you supply your own implementation of `LightweightTrace`.)
 
 ---
 <small>

--- a/tests/IncrementalGeneratorExtensions.Content.Tests.NoInstanceCache/IncrementalGeneratorExtensions.Content.Tests.NoInstanceCache.csproj
+++ b/tests/IncrementalGeneratorExtensions.Content.Tests.NoInstanceCache/IncrementalGeneratorExtensions.Content.Tests.NoInstanceCache.csproj
@@ -8,7 +8,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <!-- Verify that the full content surface compiles and behaves correctly when the
          instance cache is excluded by a consuming project. -->
-    <DefineConstants>$(DefineConstants);DATACUTE_EXCLUDE_EQUATABLEIMMUTABLEARRAYINSTANCECACHE</DefineConstants>
+    <DefineConstants>$(DefineConstants);DATACUTE_EXCLUDE_EQUATABLEIMMUTABLEARRAYINSTANCECACHE;DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE</DefineConstants>
     <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
@@ -33,4 +33,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/tests/IncrementalGeneratorExtensions.Content.Tests/IncrementalGeneratorExtensions.Content.Tests.csproj
+++ b/tests/IncrementalGeneratorExtensions.Content.Tests/IncrementalGeneratorExtensions.Content.Tests.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
     <LangVersion>latestMajor</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
+    <DefineConstants>$(DefineConstants);DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE</DefineConstants>
     <!-- xUnit1051 wants TestContext.Current.CancellationToken passed to every CT-accepting method.
          Noise for in-memory factory helpers; suppressed project-wide. -->
     <NoWarn>$(NoWarn);xUnit1051</NoWarn>

--- a/tests/IncrementalGeneratorExtensions.Content.Tests/LightweightTraceTests.cs
+++ b/tests/IncrementalGeneratorExtensions.Content.Tests/LightweightTraceTests.cs
@@ -1,3 +1,10 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+using System.Threading;
 using Xunit;
 
 namespace Datacute.IncrementalGeneratorExtensions.Tests
@@ -50,6 +57,161 @@ namespace Datacute.IncrementalGeneratorExtensions.Tests
             // Assert
             Assert.NotEqual(idOnly, differentValue);
             Assert.NotEqual(idOnly, differentId);
+        }
+
+        private enum TestTraceStage
+        {
+            StageA = 900,
+            StageB = 901
+        }
+
+        private sealed class CapturingEventListener : EventListener
+        {
+            private readonly string _eventSourceName;
+            private readonly EventLevel _level;
+            private readonly ConcurrentQueue<RecordedEvent> _events = new ConcurrentQueue<RecordedEvent>();
+            private readonly ManualResetEventSlim _enabled = new ManualResetEventSlim(false);
+
+            public CapturingEventListener(string eventSourceName, EventLevel level)
+            {
+                _eventSourceName = eventSourceName;
+                _level = level;
+            }
+
+            public RecordedEvent[] Events => _events.ToArray();
+
+            public bool WaitUntilEnabled(TimeSpan timeout) => _enabled.Wait(timeout);
+
+            public bool WaitForEventCount(int count, TimeSpan timeout)
+            {
+                return SpinWait.SpinUntil(() => _events.Count >= count, timeout);
+            }
+
+            protected override void OnEventSourceCreated(EventSource eventSource)
+            {
+                if (eventSource.Name == _eventSourceName)
+                {
+                    EnableEvents(eventSource, _level);
+                    _enabled.Set();
+                }
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventData)
+            {
+                var payload = eventData.Payload == null
+                    ? new object[0]
+                    : eventData.Payload.ToArray();
+                _events.Enqueue(new RecordedEvent(eventData.EventId, payload));
+            }
+        }
+
+        private sealed class RecordedEvent
+        {
+            public RecordedEvent(int eventId, object[] payload)
+            {
+                EventId = eventId;
+                Payload = payload;
+            }
+
+            public int EventId { get; }
+
+            public object[] Payload { get; }
+        }
+
+        [Fact]
+        public void InitializeEtw_CanBeCalledRepeatedly_WithDifferentEventSourceNames()
+        {
+            LightweightTrace.InitializeEtw(
+                eventSourceName: "Datacute-LWT-EventSource-Test-A-" + Guid.NewGuid().ToString("N"),
+                eventLevel: EventLevel.Verbose);
+            LightweightTrace.InitializeEtw(
+                eventSourceName: "Datacute-LWT-EventSource-Test-B-" + Guid.NewGuid().ToString("N"),
+                eventLevel: EventLevel.Informational);
+        }
+
+        [Fact]
+        public void EventSourceMode_EmitsExpectedTraceAndCountEvents()
+        {
+            var eventSourceName = "Datacute-LWT-EventSource-Test-" + Guid.NewGuid().ToString("N");
+            var eventNameMap = new Dictionary<int, string>
+            {
+                { (int)TestTraceStage.StageA, "Stage A" },
+                { (int)TestTraceStage.StageB, "Stage B" },
+                { 2, "Bucket Two" },
+            };
+
+            using (var listener = new CapturingEventListener(eventSourceName, EventLevel.Verbose))
+            {
+                LightweightTrace.InitializeEtw(
+                    eventSourceName: eventSourceName,
+                    eventLevel: EventLevel.Informational,
+                    eventNameMap: eventNameMap);
+
+                Assert.True(listener.WaitUntilEnabled(TimeSpan.FromSeconds(2)));
+
+                LightweightTrace.Add(TestTraceStage.StageA);
+                LightweightTrace.IncrementCount(TestTraceStage.StageB, 2, mapValue: true);
+
+                Assert.True(listener.WaitForEventCount(2, TimeSpan.FromSeconds(2)));
+
+                var events = listener.Events;
+                var trace = events.SingleOrDefault(e => e.EventId == 4 && (int)e.Payload[0] == (int)TestTraceStage.StageA);
+                var count = events.SingleOrDefault(e => e.EventId == 9 && (int)e.Payload[0] == (int)TestTraceStage.StageB);
+
+                Assert.NotNull(trace);
+                Assert.NotNull(count);
+
+                var traceId = (int)trace.Payload[0];
+                var traceValue = (int)trace.Payload[1];
+                var traceIsMappedValue = (bool)trace.Payload[2];
+                var traceMessage = (string)trace.Payload[3];
+
+                var countId = (int)count.Payload[0];
+                var countValue = (int)count.Payload[1];
+                var countIsMappedValue = (bool)count.Payload[2];
+                var countDelta = (long)count.Payload[3];
+                var countMessage = (string)count.Payload[4];
+
+                Assert.Equal((int)TestTraceStage.StageA, traceId);
+                Assert.Equal(0, traceValue);
+                Assert.False(traceIsMappedValue);
+                Assert.Equal("Stage A", traceMessage);
+
+                Assert.Equal((int)TestTraceStage.StageB, countId);
+                Assert.Equal(2, countValue);
+                Assert.True(countIsMappedValue);
+                Assert.Equal(1L, countDelta);
+                Assert.Equal("Stage B (Bucket Two)", countMessage);
+            }
+        }
+
+        [Fact]
+        public void EventSourceMode_AddAndCounts_StillProduceDiagnosticsComment()
+        {
+            var eventNameMap = new Dictionary<int, string>
+            {
+                { (int)TestTraceStage.StageA, "Stage A" },
+                { (int)TestTraceStage.StageB, "Stage B" },
+            };
+
+            LightweightTrace.InitializeEtw(
+                eventSourceName: "Datacute-LWT-EventSource-Test-C-" + Guid.NewGuid().ToString("N"),
+                eventLevel: EventLevel.Verbose,
+                eventNameMap: eventNameMap);
+
+            LightweightTrace.Add(TestTraceStage.StageA);
+            LightweightTrace.Add(TestTraceStage.StageB, 3);
+            LightweightTrace.IncrementCount(TestTraceStage.StageA, 3);
+            LightweightTrace.DecrementCount(TestTraceStage.StageA, 1);
+            LightweightTrace.SetCount(TestTraceStage.StageB, 2, mapValue: false, count: 5);
+
+            var builder = new StringBuilder();
+            builder.AppendDiagnosticsComment(eventNameMap);
+            var diagnostics = builder.ToString();
+
+            Assert.Contains("/* Diagnostics", diagnostics);
+            Assert.Contains("Counters:", diagnostics);
+            Assert.Contains("Trace Log:", diagnostics);
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds optional EventSource support to LightweightTrace while keeping the existing ring-buffer diagnostics path as the default. EventSource mode is enabled via DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE and emits structured event payloads for traces and counts. Documentation and tests were updated so this behaviour is covered in normal test runs.

## What changed
- Added compile-time optional EventSource integration in LightweightTrace behind DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE.
- Added InitializeEtw and EventSource trace/count emission paths.
- Kept default behaviour unchanged when the symbol is not defined.
- Updated docs/LightweightTrace README.md with EventSource setup and usage notes.
- Added EventListener-based assertions for EventSource payloads.
- Enabled DATACUTE_LIGHTWEIGHTTRACE_USE_EVENTSOURCE in both content test projects for single-run coverage.
- Updated CHANGELOG.md under Unreleased for the new consumer-visible capability.

## Why
- Provide real-time diagnostic event streaming alongside embedded diagnostics comments.
- Keep EventSource opt-in so current consumers retain default behaviour.
- Validate emitted payload shape/content continuously.

## Validation
- dotnet test --configuration Release (passed: 123/123)
- dotnet test -v minimal (passed: 123/123)
- Confirmed source branch is pushed and tracking origin/feature/feature-etw-support
- Confirmed CHANGELOG.md contains an Unreleased entry for this feature

## Notes
- EventSource payload fields include id, value, isMappedValue, message (and count for count events).

## Checks
- [x] Source branch is feature/feature-etw-support
- [x] Target branch is develop
- [x] Working tree is clean
- [x] CHANGELOG updated for user-visible change
- [x] Release-configuration tests passed
- [ ] Build workflow passes on this PR before merge